### PR TITLE
Add ansible playbook to set up site

### DIFF
--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -1,0 +1,67 @@
+Deployment Playbook
+===================
+
+This ansible role can be used to configure/reconfigure the ceph.io website.
+
+Prerequisites
+-------------
+
+- Ubuntu 20.04 server with a public IP
+- nginx is the only supported webserver
+- Run the ``users``, ``common``, and ``public_facing`` roles from the ceph-cm-ansible_ repo.  This is optional but is an easy way to set up user accounts, SSH keys, nagios monitoring, firewall, and fail2ban.
+
+.. _ceph-cm-ansible: https://github.com/ceph/ceph-cm-ansible
+
+Variables
+---------
+
+I'd be surprised if this playbook got reused for any purpose other than setting up ceph.io but if desired, override these vars set in ``defaults/main.yml``
+
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+|                                              | Description                                                                                   |
+| Variable                                     |                                                                                               |
++==============================================+===============================================================================================+
+| ``fqdn: beta.ceph.io``                       | Fully qualified domain name of webserver.                                                     |
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``install_dir: /opt/www``                    | Directory in which to clone and serve the ceph.io static site repo.                           |
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``branch: master``                           | Branch of this repo to serve.  This is useful for testing site changes.                       |
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``update_frequency: 5``                      | How often (in minutes) a cronjob should check for updates to this repo and publish a new site.|
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ::                                           | List of domains we should obtain letsencrypt certificates for                                 |
+|                                              |                                                                                               |
+|   letsencrypt_domains:                       |                                                                                               |
+|     - beta.ceph.io                           |                                                                                               |
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``letsencrypt_email: ceph-infra@redhat.com`` | E-mail address letsencrypt notifications should be sent to.                                   |
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ::                                           | System packages to install using `apt`.                                                       |
+|                                              |                                                                                               |
+|   packages:                                  |                                                                                               |
+|     - nginx                                  |                                                                                               |
+|     - certbot                                |                                                                                               |
+|     - npm                                    |                                                                                               |
++----------------------------------------------+-----------------------------------------------------------------------------------------------+
+
+Note that ``ufw`` and ``fail2ban`` get installed by the afformentioned public_facing_ role.
+
+.. _public_facing: https://github.com/ceph/ceph-cm-ansible/tree/master/roles/public_facing
+
+Tags
+----
+
+``packages``: Just installs and updates packages
+
+``nginx``: Performs nginx-only tasks
+
+``letsencrypt``: Only creates or renews cert
+
+``npm``: Just does the git and npm tasks
+
+How-Tos
+-------
+
+To just update the branch the site serves from (We used the ``develop`` branch when setting up the static site), run::
+
+    ansible-playbook run.yml -e branch=$branch --tags npm

--- a/ansible/roles/deploy/defaults/main.yml
+++ b/ansible/roles/deploy/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+fqdn: beta.ceph.io
+install_dir: /opt/www
+branch: master
+update_frequency: 5
+letsencrypt_domains:
+  - beta.ceph.io
+letsencrypt_email: ceph-infra@redhat.com
+packages:
+  - nginx
+  - certbot
+  - python3-certbot-nginx
+  - npm
+  - vim
+  - net-tools

--- a/ansible/roles/deploy/handlers/main.yml
+++ b/ansible/roles/deploy/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart nginx
+  service:
+    name: nginx
+    state: restarted
+
+- name: Reload nginx
+  service:
+    name: nginx
+    state: reloaded

--- a/ansible/roles/deploy/tasks/main.yml
+++ b/ansible/roles/deploy/tasks/main.yml
@@ -1,0 +1,121 @@
+---
+- name: Install packages
+  apt:
+    name: "{{ packages }}"
+    state: latest
+    update_cache: yes
+  tags:
+    - packages
+
+- name: Ensure a home for the site
+  file:
+    path: "{{ install_dir }}"
+    state: directory
+    owner: www-data
+    group: www-data
+  tags:
+    - npm
+
+- name: Clone or update the repo
+  git:
+    repo: https://github.com/ceph/ceph.io
+    dest: "{{ install_dir }}"
+    force: yes
+    update: yes
+  tags:
+    - npm
+
+- name: Check out desired branch
+  command:
+    cmd: "git checkout {{ branch }}"
+    chdir: "{{ install_dir }}"
+  tags:
+    - npm
+
+# I couldn't get the npm module working here
+#- name: Install npm dependencies
+#  npm:
+#    path: "{{ install_dir }}"
+#    state: latest
+
+- name: Install npm dependencies
+  command:
+    cmd: npm install
+    chdir: "{{ install_dir }}"
+  tags:
+    - npm
+
+- name: Compile site
+  command:
+    cmd: npm run build
+    chdir: "{{ install_dir }}"
+  tags:
+    - npm
+
+- name: Update file permissions
+  file:
+    path: "{{ install_dir }}/dist"
+    owner: www-data
+    group: www-data
+    recurse: yes
+  tags:
+    - npm
+
+# TODO: Nginx global config if needed
+
+- name: Ensure nginx default config is absent
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  tags:
+    - nginx
+
+- name: Put nginx site config in place
+  template:
+    src: site.j2
+    dest: /etc/nginx/sites-available/site.conf
+  notify: Restart nginx
+  tags:
+    - nginx
+
+- name: Ensure symlink to nginx site config
+  file:
+    src: /etc/nginx/sites-available/site.conf
+    dest: /etc/nginx/sites-enabled/site.conf
+    state: link
+  notify: Restart nginx
+  tags:
+    - nginx
+
+# At the time of role creation, I had to do this first: https://community.letsencrypt.org/t/ubuntu-20-04-any-tips-attributeerror-module-acme-challenges-has-no-attribute-tlssni01/115831/12
+- name: Get letsencrypt certs
+  command: certbot --nginx --agree-tos {% for domain in letsencrypt_domains %}-d {{ domain }} {% endfor %} -m {{ letsencrypt_email }} --redirect --reinstall
+  notify: Reload nginx
+  tags:
+    - letsencrypt
+
+- name: Put nginx security directives in place
+  blockinfile:
+    path: /etc/nginx/sites-available/site.conf
+    insertafter: ssl_dhparam*
+    block: |
+            add_header Strict-Transport-Security "max-age=31536000";
+            server_tokens off;
+            add_header X-Frame-Options SAMEORIGIN;
+            add_header X-Content-Type-Options nosniff;
+            add_header X-XSS-Protection "1; mode=block";
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'";
+            proxy_cookie_path / "/; HTTPOnly; Secure";
+  tags:
+    - nginx
+
+- name: Validate nginx site config
+  command: nginx -t
+  tags:
+    - nginx
+
+- name: Create cronjob to automatically update site
+  cron:
+    name: "Update static site"
+    minute: "*/{{ update_frequency }}"
+    job: "cd {{ install_dir }} && git pull && npm install && npm run build && chown -R www-data:www-data {{ install_dir }}"

--- a/ansible/roles/deploy/templates/site.j2
+++ b/ansible/roles/deploy/templates/site.j2
@@ -1,0 +1,10 @@
+# This file is managed by https://github.com/ceph/ceph.io.  Do not make changes manually.
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name {{ fqdn }};
+
+  root {{ install_dir }}/dist;
+  index index.html;
+}

--- a/ansible/run.yml
+++ b/ansible/run.yml
@@ -1,0 +1,5 @@
+---
+- hosts: beta.ceph.io
+  roles:
+    - deploy
+  become: true


### PR DESCRIPTION
We'll obviously need to replace `beta.ceph.io` with `ceph.io` in the future but this is working for now with `ansible-playbook -e branch=develop run.yml`

Signed-off-by: David Galloway <dgallowa@redhat.com>