### PR TITLE
Update main README with user-friendly directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ceph.io
 
-:warning: **To report an issue with the [ceph.io](https://ceph.io/) website**: file it with the [live website repository], not here.
+:warning: **To report an issue with the [ceph.io](https://ceph.io/) website**, email *Ceph Community Manager* Mike Perez at <miperez@redhat.com>. Please include a brief description of the problem and the link that led to it.
 
 This repository is for the *new website*, which is currently under development. All work happens in the `develop` branch.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # ceph.io
+
+:warning: **To report an issue with the [ceph.io](https://ceph.io/) website**: file it with the [live website repository], not here.
+
+This repository is for the *new website*, which is currently under development. All work happens in the `develop` branch.
+
+If you'd like to contribute, please see [WHAT].

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # ceph.io
 
-:warning: **To report an issue with the [ceph.io](https://ceph.io/) website**, email *Ceph Community Manager* Mike Perez at <miperez@redhat.com>. Please include a brief description of the problem and the link that led to it.
 
-This repository is for the *new website*, which is currently under development. All work happens in the `develop` branch.
+## :warning: Something wrong with ceph.io website?
 
-If you'd like to contribute, please see [WHAT].
+Report any website issues you experience by email to **Mike Perez** <miperez@redhat.com>, *Ceph Community Manager*. Please include a brief description of the problem and a link that led to it. 
+
+## :question: What's in this repository?
+
+This repository is for the *new website*, which is currently under development. The development activity is in the `develop` branch.
+
+## :octopus: Contributing to Ceph Project
+
+A great starting point for an aspiring contributor is the following guide: [Contributing to Ceph: A Guide for Developers](https://docs.ceph.com/docs/master/dev/developer_guide/).


### PR DESCRIPTION
The ceph.io website as of now is not friendly towards those who would like to fix or at least to report mistakes on the website. This repo does not make it clear that it is for the new website under development and this creates confusion. See issue #3 for an example. It is safe to assume that the majority of people who would have otherwise reported or even fixed mistakes give up early in the process. This update provides direction for reports related to the current website and makes a statement about this repository's purpose as a home for the new website.

I still haven't found the information I require, so the following stubs in the README body must be updated:

- [x] include the _current_ website repo location in this README or note the way in which website maintainers can be reached
- [x] if contributions to the _new_ website are welcome, include the link to contributors guide

In distributed projects, communication is _everything_. Please feel free to amend the proposed changes as you see fit. I only wanted to show the direction.