### PR TITLE
ansible: Also include the default mime.types

### DIFF
--- a/ansible/roles/deploy/templates/site.j2
+++ b/ansible/roles/deploy/templates/site.j2
@@ -53,6 +53,7 @@ server {
   proxy_cookie_path / "/; HTTPOnly; Secure";
 
   # https://github.com/ceph/ceph.io/issues/101
+  include mime.types;
   types {
     application/javascript mjs;
   }
@@ -115,6 +116,7 @@ server {
   proxy_cookie_path / "/; HTTPOnly; Secure";
 
   # https://github.com/ceph/ceph.io/issues/101
+  include mime.types;
   types {
     application/javascript mjs;
   }


### PR DESCRIPTION
I guess specifying `types { }` in a block higher than `http { }` overrides all of the default mime types so we need to manually include it at the same level again.

https://stackoverflow.com/a/20566966/6225562

Signed-off-by: David Galloway <dgallowa@redhat.com>