### PR TITLE
Add `application/json` to gzip types, `mjs` MIME type update

### DIFF
--- a/ansible/roles/deploy/templates/site.j2
+++ b/ansible/roles/deploy/templates/site.j2
@@ -55,7 +55,7 @@ server {
   # https://github.com/ceph/ceph.io/issues/101
   include mime.types;
   types {
-    application/javascript mjs;
+    text/javascript mjs;
   }
 
   # https://github.com/ceph/ceph.io/issues/104
@@ -118,7 +118,7 @@ server {
   # https://github.com/ceph/ceph.io/issues/101
   include mime.types;
   types {
-    application/javascript mjs;
+    text/javascript mjs;
   }
 
   # https://github.com/ceph/ceph.io/issues/104

--- a/ansible/roles/deploy/templates/site.j2
+++ b/ansible/roles/deploy/templates/site.j2
@@ -60,7 +60,7 @@ server {
 
   # https://github.com/ceph/ceph.io/issues/104
   gzip on;
-  gzip_types text/css text/javascript;
+  gzip_types application/json text/css text/javascript;
 }
 
 
@@ -123,5 +123,5 @@ server {
 
   # https://github.com/ceph/ceph.io/issues/104
   gzip on;
-  gzip_types text/css text/javascript;
+  gzip_types application/json text/css text/javascript;
 }


### PR DESCRIPTION
Following on from #104, it would be great if we could gzip `application/json` files. We'll have a few static JSON assets (search indices, etc.) which would benefit a lot from compression.

@djgalloway is this fair game/all we need to include?

Related, we currently have `text/javascript` included in our gzip types, but we set the `.mjs` MIME type to `application/javascript`. Based on [a little](https://github.com/google/WebFundamentals/issues/7549) [digging](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types), I've also updated this to `text/javascript` to ensure they're gzipped as intended. Shout if this isn't in line with your expectations.