### PR TITLE
Richtext image width

### DIFF
--- a/src/_11ty/shortcodes/ArticleCard.js
+++ b/src/_11ty/shortcodes/ArticleCard.js
@@ -18,7 +18,7 @@ module.exports = (
       <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-4 rounded-2">
         <img
           alt="" 
-          class="absolute h-full left-0 rounded-2 top-0"
+          class="absolute h-full left-0 rounded-2 top-0 w-full"
           loading="lazy"
           src="${imageSrc}" 
         />

--- a/src/_11ty/shortcodes/ArticleCard.js
+++ b/src/_11ty/shortcodes/ArticleCard.js
@@ -15,7 +15,7 @@ module.exports = (
 
   return `
     <div class="relative">
-      <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-4 rounded-2">
+      <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--cover mb-4 rounded-2">
         <img
           alt="" 
           class="absolute h-full left-0 rounded-2 top-0 w-full"

--- a/src/_includes/components/case-study-card.njk
+++ b/src/_includes/components/case-study-card.njk
@@ -1,5 +1,5 @@
 <div class="relative">
-  <div class="aspect-ratio aspect-ratio--16x9 mb-4">
+  <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--cover mb-4">
     <img alt="" class="absolute h-full left-0 rounded-2 top-0 w-full" loading="lazy" src="{% if item.data.image %}{{ item.data.image }}{% else %}/assets/bitmaps/photo-water-02.jpg{% endif %}" />
   </div>
   <a class="a link-cover" href="{{ item.url }}">{{ item.data.title }}</a>

--- a/src/_includes/components/case-study-card.njk
+++ b/src/_includes/components/case-study-card.njk
@@ -1,6 +1,6 @@
 <div class="relative">
   <div class="aspect-ratio aspect-ratio--16x9 mb-4">
-    <img alt="" class="absolute left-0 rounded-2 top-0" loading="lazy" src="{% if item.data.image %}{{ item.data.image }}{% else %}/assets/bitmaps/photo-water-02.jpg{% endif %}" />
+    <img alt="" class="absolute h-full left-0 rounded-2 top-0 w-full" loading="lazy" src="{% if item.data.image %}{{ item.data.image }}{% else %}/assets/bitmaps/photo-water-02.jpg{% endif %}" />
   </div>
   <a class="a link-cover" href="{{ item.url }}">{{ item.data.title }}</a>
 </div>

--- a/src/_includes/components/case-study-category-card.njk
+++ b/src/_includes/components/case-study-category-card.njk
@@ -1,8 +1,10 @@
 {# We will need a way to randomise the image as case study categories don't contain an image. 
 We should only need a selection of 6 assets as we only show 6 case study categories. #}
 
+{# UPDATE - This component may no longer be needed due to the IA update moving case studies under discover #}
+
 <div class="bg-grey-300 border-grey-500 border-px border-solid relative rounded-2">
-  <div class="aspect-ratio aspect-ratio--16x9">
+  <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--cover">
     <img alt="" class="absolute h-full left-0 rounded-t-2 top-0 w-full" loading="lazy" src="/assets/bitmaps/photo-water-02.jpg" />
   </div>
   <a class="block color-red-500 h3 link-cover link-cover--shadow mb-0 p-6 text-capitalise" href="/{{ locale }}/discover/case-studies/category/{{ item | slug }}/">{{ item }}</a>

--- a/src/_includes/components/case-study-category-card.njk
+++ b/src/_includes/components/case-study-category-card.njk
@@ -3,7 +3,7 @@ We should only need a selection of 6 assets as we only show 6 case study categor
 
 <div class="bg-grey-300 border-grey-500 border-px border-solid relative rounded-2">
   <div class="aspect-ratio aspect-ratio--16x9">
-    <img alt="" class="absolute left-0 rounded-t-2 top-0" loading="lazy" src="/assets/bitmaps/photo-water-02.jpg" />
+    <img alt="" class="absolute h-full left-0 rounded-t-2 top-0 w-full" loading="lazy" src="/assets/bitmaps/photo-water-02.jpg" />
   </div>
   <a class="block color-red-500 h3 link-cover link-cover--shadow mb-0 p-6 text-capitalise" href="/{{ locale }}/discover/case-studies/category/{{ item | slug }}/">{{ item }}</a>
 </div>

--- a/src/_includes/components/event-card.njk
+++ b/src/_includes/components/event-card.njk
@@ -1,5 +1,5 @@
 <div class="relative">
-  <div class="aspect-ratio aspect-ratio--16x9 mb-4">
+  <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--cover mb-4">
     <img alt="" class="absolute h-full left-0 rounded-2 top-0 w-full" loading="lazy" src="{% if item.data.image %}{{ item.data.image }}{% else %}/assets/bitmaps/photo-water-02.jpg{% endif %}" />
   </div>
   <a class="block color-navy link-cover h4 mb-2" href="{{ item.url }}">

--- a/src/_includes/components/event-card.njk
+++ b/src/_includes/components/event-card.njk
@@ -1,6 +1,6 @@
 <div class="relative">
   <div class="aspect-ratio aspect-ratio--16x9 mb-4">
-    <img alt="" class="absolute left-0 rounded-2 top-0" loading="lazy" src="{% if item.data.image %}{{ item.data.image }}{% else %}/assets/bitmaps/photo-water-02.jpg{% endif %}" />
+    <img alt="" class="absolute h-full left-0 rounded-2 top-0 w-full" loading="lazy" src="{% if item.data.image %}{{ item.data.image }}{% else %}/assets/bitmaps/photo-water-02.jpg{% endif %}" />
   </div>
   <a class="block color-navy link-cover h4 mb-2" href="{{ item.url }}">
     {{ item.data.title }}

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -21,7 +21,7 @@ layout: navigation
       {% if image %}
         <div class="to-lg:w-full-breakout">
           <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0" loading="lazy" src="{{ image }}" />
+            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
           </div>
         </div>
       {% endif %}

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -20,9 +20,7 @@ layout: navigation
     <div>
       {% if image %}
         <div class="to-lg:w-full-breakout">
-          <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
-          </div>
+          <img alt="" class="mb-8 lg:mb-10 xl:mb-12 w-full" loading="lazy" src="{{ image }}" />
         </div>
       {% endif %}
       <div class="intro-para richtext">

--- a/src/_includes/layouts/case-study.njk
+++ b/src/_includes/layouts/case-study.njk
@@ -11,9 +11,7 @@ layout: navigation
     <div>
       {% if image %}
         <div class="to-lg:w-full-breakout">
-          <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
-          </div>
+          <img alt="" class="mb-8 lg:mb-10 xl:mb-12 w-full" loading="lazy" src="{{ image }}" />
         </div>
       {% endif %}
       <div class="intro-para richtext">

--- a/src/_includes/layouts/case-study.njk
+++ b/src/_includes/layouts/case-study.njk
@@ -12,7 +12,7 @@ layout: navigation
       {% if image %}
         <div class="to-lg:w-full-breakout">
           <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0" loading="lazy" src="{{ image }}" />
+            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
           </div>
         </div>
       {% endif %}

--- a/src/_includes/layouts/event.njk
+++ b/src/_includes/layouts/event.njk
@@ -24,7 +24,7 @@ layout: navigation
       {% if image %}
         <div class="to-lg:w-full-breakout">
           <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0" loading="lazy" src="{{ image }}" />
+            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
           </div>
         </div>
       {% endif %}

--- a/src/_includes/layouts/event.njk
+++ b/src/_includes/layouts/event.njk
@@ -23,9 +23,7 @@ layout: navigation
       {% endif %}
       {% if image %}
         <div class="to-lg:w-full-breakout">
-          <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
-          </div>
+          <img alt="" class="mb-8 lg:mb-10 xl:mb-12 w-full" loading="lazy" src="{{ image }}" />
         </div>
       {% endif %}
       <div class="intro-para richtext">

--- a/src/_includes/layouts/press-release.njk
+++ b/src/_includes/layouts/press-release.njk
@@ -21,7 +21,7 @@ layout: navigation
       {% if image %}
         <div class="to-lg:w-full-breakout">
           <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0" loading="lazy" src="{{ image }}" />
+            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
           </div>
         </div>
       {% endif %}

--- a/src/_includes/layouts/press-release.njk
+++ b/src/_includes/layouts/press-release.njk
@@ -20,9 +20,7 @@ layout: navigation
     <div>
       {% if image %}
         <div class="to-lg:w-full-breakout">
-          <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--contain bg-grey-500 mb-8 lg:mb-10 xl:mb-12">
-            <img alt="" class="absolute h-full top-0 w-full" loading="lazy" src="{{ image }}" />
-          </div>
+          <img alt="" class="mb-8 lg:mb-10 xl:mb-12 w-full" loading="lazy" src="{{ image }}" />
         </div>
       {% endif %}
       <div class="intro-para richtext">

--- a/src/css/base.document.css
+++ b/src/css/base.document.css
@@ -44,7 +44,5 @@ nav li::before {
 
 img,
 canvas {
-  height: auto;
   max-width: 100%;
-  width: 100%;
 }

--- a/src/css/base.media.css
+++ b/src/css/base.media.css
@@ -15,6 +15,10 @@
   }
 }
 
+.richtext img:not([height]) {
+  height: auto;
+}
+
 .richtext img:not([width]) {
   width: auto;
 }

--- a/src/css/base.media.css
+++ b/src/css/base.media.css
@@ -2,16 +2,21 @@
 
 /* image */
 .richtext img {
-  --richtext-img-gutters-y: var(--size-4);
-  margin: var(--richtext-img-gutters-y) 0;
+  --richtext-img-gutters-y: var(--size-6);
+  display: block;
+  margin: var(--richtext-img-gutters-y) auto;
 
   @media (--mq-lg) {
-    --richtext-img-gutters-y: var(--size-6);
+    --richtext-img-gutters-y: var(--size-10);
   }
 
   @media (--mq-xl) {
-    --richtext-img-gutters-y: var(--size-8);
+    --richtext-img-gutters-y: var(--size-14);
   }
+}
+
+.richtext img:not([width]) {
+  width: auto;
 }
 
 /*


### PR DESCRIPTION
- Richtext CSS so images are no wider than their native width but remain responsive

We have a global declaration for `img` that forces images to be 100% width of their parent container. I've removed this so where necessary we'll have to use the `w-full` utility class if we want an image to be 100% width of its container. It's been removed because as long as we have a global width declaration in the CSS, whether it be `auto` or `100%`, we won't be able to honor a width attribute on an `<img>`. It can be overriden by adding a `class` to the `img` but it's in the interest of keeping the markdown simple and not needing an awareness of our utility width classes.

Images that do appear in a `richtext` container will now be no wider than their native width but remain responsive, they will also appear center aligned.

If an alternative width is required for `richtext` images we'd need to use the proper HTML markup `<img src="asset.jpg" alt="" width="100" />` with a width declaration. The image would still be responsive but no wider than the declared width.

Closes #120 