### PR TITLE
news/index.html: add subscribe link

### DIFF
--- a/src/en/news/index.html
+++ b/src/en/news/index.html
@@ -86,7 +86,7 @@ order: 5
         <a class="a" href="#">Other ways to stay connected</a>
       </div>
       <div>
-        <a class="button" href="#">Subscribe to Ceph Announcements</a>
+        <a class="button" href="https://lists.ceph.io/postorius/lists/ceph-announce.ceph.io/">Subscribe to Ceph Announcements</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a link to the subscription page
of the ceph-announcement mailing list. This link
is added to the placeholder button reading
"Subscribe to Ceph Announcements".

Signed-off-by: Zac Dover <zac.dover@gmail.com>