### PR TITLE
ceph.io/roadmap: cleaning up roadmap

### DIFF
--- a/src/en/developers/roadmap/index.md
+++ b/src/en/developers/roadmap/index.md
@@ -8,24 +8,17 @@ order: 4
 
 ## Ceph is the Future of Storage
 
-**See the future of Ceph and how we plan to get there.**
+### Trello Board
 
-Ceph relies on contributions from its community around the world to stay at the forefront of software-defined storage innovation. With a strong and driven community and an ever-growing plethora of users, Ceph will continue to be shaped and developed by those who use it, for those who use it.
+The Ceph upstream community uses a Trello board to track future plans and
+features. Check it out here:
 
-### Constant Releases and A Proactive Approach
+[Ceph Trello Board](https://trello.com/b/ugTc2QFH/ceph-backlog)
 
-Ceph is constantly updated, developed and improved to further the scalability, reliability and performance of the software. Releasing a new stable release every year, the Ceph community ensures users benefit from innovative developments and improvements. This proactive approach keeps Ceph ahead as the future of storage.
+### Issue Tracker 
 
-[Ceph releases]()
+The Ceph upstream community uses a Redmine instance to track issues under
+development.  Check it out here:
 
-### Issue Tracking for Future Success
+[Ceph Issue Tracker](https://tracker.ceph.com/)
 
-Using Ceph’s live issue tracker, community developers get an instant overview of where their expertise can be applied. From individual releases to specific features of Ceph, Ceph’s tracker is a vital resource outlining the current progress.
-
-[View Ceph’s tracker]()
-
-### Ceph’s Vision
-
-Ceph has grown from a PhD thesis to a global phenomenon, attracting the best and most enthusiastic developers, engineers and architects to create scalable software-defined storage able to accommodate the exponential growth of data. Users of Ceph are at the core of every development; if you use Ceph, you can shape its future. Combining this user-centric approach, which aims to simplify deployment without compromising scalability, with the successful Open Source philosophy ensures Ceph is, and always will be, the future of storage.
-
-[Ceph’s vision](../../discover/vision/)


### PR DESCRIPTION
This is the first PR that removes the marketing-
speak from the Roadmap page on ceph.io.

Signed-off-by: Zac Dover <zac.dover@gmail.com>