### PR TITLE
ceph.io/developers: rewriting marketing copy 1

### DIFF
--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -14,8 +14,8 @@ overlaySubMenu: true
     </div>
     <div class="wrapper">
       <div class="color-white max-w-224 mx-auto relative text-center z-1">
-        <h2 class="h1">Evolve with Ceph. Evolve with&nbsp;data.</h2>
-        <p class="mb-0 standout">Ceph’s capabilities can be engineered by&nbsp;you.</p>
+        <h2 class="h1">Ceph. The Linux of storage.</h2>
+        <p class="mb-0 standout">Solving storage problems with open-source software.</p>
       </div>
     </div>
   </div>
@@ -24,23 +24,21 @@ overlaySubMenu: true
     <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
       <div>
         <p class="standout">
-          Ceph’s community drives innovation and are critical to the successful and performant continuation of Ceph as an industry leading
-          software-defined storage system. Becoming a Ceph developer means you belong to a global community of passionate, talented and
-          inspired developers, with the common goal of making Ceph the best it can be.
-        </p>
-        <a class="button" href="/{{ locale }}/users/documentation/">Get started with Ceph</a>
+          Ceph is a project committed to the idea that all storage problems should be solvable with open-source software. To learn how to make a contribution to the Ceph project, click the link below.
+	</p>
+        <a class="button" href="https://docs.ceph.com/en/latest/dev/developer_guide/intro/">Get started with Ceph</a>
       </div>
       <div class="bg-grey-300 p-5 rounded-2">
-        <h3 class="h3">Lorem ipsum</h3>
+        <h3 class="h3">Ceph Git Repository</h3>
         <p class="mb-8 lg:mb-12 p">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in dui sed arcu ullamcorper rhoncus. Maecenas lacus ligula, aliquam
-          quis elit vitae, congue viverra libero.
-        </p>
-        <h3 class="h3">Lorem ipsum</h3>
+	Ceph uses a Github repository for development. Click the button below to check it out. Fork the Ceph repository to begin contributing.
+	</p>
+        <a class="button" href="https://github.com/ceph/ceph">Ceph Github Repository</a>
+        <h3 class="h3">Ceph Issue Tracker</h3>
         <p class="mb-0 p">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in dui sed arcu ullamcorper rhoncus. Maecenas lacus ligula, aliquam
-          quis elit vitae, congue viverra libero.
+	Ceph uses a Redmine instance to track issues. Search for known issues and report new issues. Click the button below to access the issue tracker.
         </p>
+        <a class="button" href="https://tracker.ceph.com">Ceph Issue Tracker</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This is the first PR in a series of PRs that will
remove the marketing copy on the Developers page of the
ceph.io website. This PR:

- Links to the part of the Developer Guide that
  explains how to make a PR to the Ceph Github
  repo.
- Provides a link to the Github repo.
- Provides a link to the Ceph Issue Tracker (the
  Redmine instance).

This provides the three basic tools that a potential
contributor will need to make a contribution to the
project.

Note: there will be more PRs to this file in the near
future after I consult with Sage. If you are not Sage
and you are reading this, don't think that this is the
only change that is being made to this page.

Signed-off-by: Zac Dover <zac.dover@gmail.com>