### PR TITLE
ceph.io/developers: update docs link

### DIFF
--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -59,10 +59,12 @@ overlaySubMenu: true
           <div class="p-5">
             <h3 class="h3">Documentation</h3>
             <p class="p">
-              Find out everything you need to know about Ceph, including component, guides, coding and more, with our extensive
-              documentation library. From here you can get started with Ceph.
-            </p>
-            <a class="a link-cover link-cover--shadow" href="/{{ locale }}/users/documentation/">Get started with Ceph (documentation)</a>
+	      Slake your thirst for Ceph knowledge. Consult the documentation
+	      to learn how to deploy a Ceph cluster, how to manage a Ceph
+	      cluster, what the components of a Ceph cluster are, how to
+	      secure your Ceph cluster, and how to get involved with the Ceph
+	      community.             </p>
+            <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/start/intro/">Get started with Ceph (documentation)</a>
           </div>
         </div>
       </li>


### PR DESCRIPTION
This PR:

- Links to the "Intro to Ceph" docs on docs.ceph.com.
- Updates the flavor text so that it refers to things that
  are in the docs.

Signed-off-by: Zac Dover <zac.dover@gmail.com>