### PR TITLE
ceph.io/developers: rewrite "code" page

### DIFF
--- a/src/en/developers/code/index.html
+++ b/src/en/developers/code/index.html
@@ -4,3 +4,26 @@ order: 2
 ---
 
 <h1>{{ title }}</h1>
+
+<div class="pb-0 section wrapper">
+    <h2 class="h2 mb-12 lg:mb-16">Start using Ceph today</h2>
+    <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+      <div>
+        <p class="standout">
+	Fork and clone the Ceph Github repository today. If you prefer to work with a Ceph tarball, you'll find many Ceph tarballs at the tarball link on this page.
+        </p>
+      </div>
+      <div class="bg-grey-300 p-5 rounded-2">
+        <h3 class="h3">Ceph Github Repository</h3>
+        <p class="mb-8 lg:mb-12 p">
+	The Ceph Github repository contains the code for the Ceph project.
+        </p>
+	<a class="button" href="https://github.com/ceph/ceph">Ceph Github Repository</a>
+        <h3 class="h3">Ceph Tarballs</h3>
+        <p class="mb-0 p">
+	Ceph tarballs are available at the link here.
+        </p>
+	<a class="button" href="https://download.ceph.com/tarballs">Ceph Tarball Downloads</a>
+      </div>
+    </div>
+  </div>


### PR DESCRIPTION
- Add link to Github repository
- Add link to Ceph tarballs

I think the leading (rhymes with "bedding", means
"space between one line of text and the next") between the
buttons and the headings is awful, but we'll return to fix
this later.

Signed-off-by: Zac Dover <zac.dover@gmail.com>