### PR TITLE
ceph.io/news: removing lorem ipsum

### DIFF
--- a/src/en/news/index.html
+++ b/src/en/news/index.html
@@ -82,7 +82,7 @@ order: 5
     <div class="flex flex--align-center flex--gap-6 flex--justify-between flex--wrap">
       <div>
         <h2 class="h3">Subscribe to Ceph Announcements</h2>
-        <p class="p">Ned placerat est a augue pulvinar imperdiet quis in setiam euismod.</p>
+        <p class="p">Click here to subscribe to the ceph-announce mailing list.</p>
         <a class="a" href="#">Other ways to stay connected</a>
       </div>
       <div>


### PR DESCRIPTION
This PR removes lorem ipsum text from a division containing
a button that links to the subscription page for ceph-announce.
I missed it the other day when I was adding the button.

Signed-off-by: Zac Dover <zac.dover@gmail.com>