### PR TITLE
ceph.io/discover: change header text

### DIFF
--- a/src/en/discover/index.html
+++ b/src/en/discover/index.html
@@ -16,7 +16,7 @@ overlaySubMenu: true
     </div>
     <div class="wrapper">
       <div class="color-white max-w-224 mx-auto relative text-center z-1">
-        <h2 class="h1 mb-0">Achieve excellent performance, reliability and scalability with&nbsp;Ceph.</h2>
+        <h2 class="h1 mb-0">Ceph. The future of storage.</h2>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR changes the header text from "Achieve
excellent performance, reliability and scalabitily
with Ceph." to "Ceph. The future of storage.".

I'm putting this in a PR now so that I can get it out
of the way. Fixing this is going to be a death of a
thousand cuts.

Signed-off-by: Zac Dover <zac.dover@gmail.com>