### PR TITLE
ceph.io/community -- added c-users and c-announce

### DIFF
--- a/src/en/community/connect/index.html
+++ b/src/en/community/connect/index.html
@@ -20,19 +20,40 @@ order: 4
           <h4 class="h4 mb-0 text-normal">ceph-announce</h4>
         </div>
         <div>
-          <a class="button" href="#">Subscribe</a>
+          <a class="button" href="http://lists.ceph.com/listinfo.cgi/ceph-announce-ceph.com">Subscribe</a>
         </div>
       </div>
 
       <div class="flex flex--align-center flex--gap-4 flex--justify-between flex--wrap mb-4">
         <a class="a" href="mailto:ceph-announce@ceph.io">ceph-announce@ceph.io</a>
-        <a class="a" href="#">View archives</a>
+        <a class="a" href="http://lists.ceph.com/pipermail/ceph-announce-ceph.com/">View archives</a>
       </div>
 
       <p class="p mb-0">
-        Sed velit justo, pellentesque at fermentum sed, mollis at ligula. Sed interdum ante non aliquet dapibus dolor lorem volutpat felis
-        sit amet lobortis.
+      The mailing list for news about Ceph releases.
       </p>
     </div>
-  </div>
+
+<div class="bg-grey-300 p-5 rounded-2">
+      <div class="flex flex--align-center flex--gap-4 flex--justify-between flex--wrap mb-4">
+        <div>
+          <h3 class="h3 mb-1">Ceph Users</h3>
+          <h4 class="h4 mb-0 text-normal">ceph-users</h4>
+        </div>
+        <div>
+          <a class="button" href="http://lists.ceph.com/listinfo.cgi/ceph-users-ceph.com">Subscribe</a>
+        </div>
+      </div>
+
+      <div class="flex flex--align-center flex--gap-4 flex--justify-between flex--wrap mb-4">
+        <a class="a" href="mailto:ceph-users@ceph.io">ceph-users@ceph.io</a>
+        <a class="a" href="http://lists.ceph.com/pipermail/ceph-users-ceph.com/">View archives</a>
+      </div>
+	<p>
+         The general mailing list for Ceph users.
+        </p>
+    </div>
+
+      
+
 </section>


### PR DESCRIPTION
I added tidy little divisions containing information
about "ceph-announce" and "ceph-users" to the "Community
Connect" page.

A future PR should probably put the "Ceph Users" division
in the right grid column, so that it looks tidy.

This is not a formatting PR. This is a content PR.

Signed-off-by: Zac Dover <zac.dover@gmail.com>