### PR TITLE
Excluded irrelevant categories from blog posts and press releases

### DIFF
--- a/src/_includes/layouts/listing-blog-post-categories.njk
+++ b/src/_includes/layouts/listing-blog-post-categories.njk
@@ -40,7 +40,7 @@
 
 {% set blogPostLocaleTag = locale + '-blog-post' %}
 {% set articleLocaleTag = locale + '-article' %}
-{% set blogPostFilters = collections[blogPostLocaleTag] | getCollectionTags([blogPostLocaleTag, articleLocaleTag]) %}
+{% set blogPostFilters = collections[blogPostLocaleTag] | getCollectionTags([blogPostLocaleTag, articleLocaleTag, 'blog-post']) %}
 {% set blogPostCategories = collections[tag] | getCollectionByTag(blogPostLocaleTag) | reverse %}
 
 <section class="section">

--- a/src/_includes/layouts/listing-blog-posts.njk
+++ b/src/_includes/layouts/listing-blog-posts.njk
@@ -7,7 +7,7 @@
 
 {% set blogPostLocaleTag = locale + '-blog-post' %}
 {% set articleLocaleTag = locale + '-article' %}
-{% set blogPostFilters = collections[blogPostLocaleTag] | getCollectionTags([blogPostLocaleTag, articleLocaleTag]) %}
+{% set blogPostFilters = collections[blogPostLocaleTag] | getCollectionTags([blogPostLocaleTag, articleLocaleTag, 'blog-post']) %}
 {% set blogPosts = pagination.items | reverse %}
 
 <section class="section">

--- a/src/_includes/layouts/listing-press-release-categories.njk
+++ b/src/_includes/layouts/listing-press-release-categories.njk
@@ -39,7 +39,7 @@
 
 {% set pressReleaseLocaleTag = locale + '-press-release' %}
 {% set articleLocaleTag = locale + '-article' %}
-{% set pressReleaseFilters = collections[pressReleaseLocaleTag] | getCollectionTags([pressReleaseLocaleTag, articleLocaleTag]) %}
+{% set pressReleaseFilters = collections[pressReleaseLocaleTag] | getCollectionTags([pressReleaseLocaleTag, articleLocaleTag, 'press-release']) %}
 {% set pressReleaseCategories = collections[tag] | getCollectionByTag(pressReleaseLocaleTag) | reverse %}
 
 <section class="section">

--- a/src/_includes/layouts/listing-press-releases.njk
+++ b/src/_includes/layouts/listing-press-releases.njk
@@ -7,7 +7,7 @@ permalink: '/{{ locale }}/news/press-releases{% if pagination.pageNumber > 0 %}/
 
 {% set pressReleaseLocaleTag = locale + '-press-release' %}
 {% set articleLocaleTag = locale + '-article' %}
-{% set pressReleaseFilters = collections[pressReleaseLocaleTag] | getCollectionTags([pressReleaseLocaleTag, articleLocaleTag]) %}
+{% set pressReleaseFilters = collections[pressReleaseLocaleTag] | getCollectionTags([pressReleaseLocaleTag, articleLocaleTag, 'press-release']) %}
 {% set pressReleases = pagination.items | reverse %}
 
 <section class="section">


### PR DESCRIPTION
Excluded these categories `blog-post` and `press-release` as they are used for other functionality in the site.

Closes #162 