### PR TITLE
ceph.io/users: add telemetry dashboard

### DIFF
--- a/src/en/users/index.html
+++ b/src/en/users/index.html
@@ -23,23 +23,19 @@ overlaySubMenu: true
     <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
       <div>
         <p class="standout">
-          Ceph’s community drives innovation and are critical to the successful and performant continuation of Ceph as an industry leading
-          software-defined storage system. Becoming a Ceph developer means you belong to a global community of passionate, talented and
-          inspired developers, with the common goal of making Ceph the best it can be.
+	The Ceph Foundation believes that all storage problems should be solvable with open-source software.
         </p>
-        <a class="button" href="/{{ locale }}/users/documentation/">Get started with Ceph</a>
+        <a class="button" href="https://docs.ceph.com/">Get started with Ceph</a>
       </div>
       <div class="bg-grey-300 p-5 rounded-2">
-        <h3 class="h3">Lorem ipsum</h3>
+        <h3 class="h3">Telemetry</h3>
         <p class="mb-8 lg:mb-12 p">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in dui sed arcu ullamcorper rhoncus. Maecenas lacus ligula, aliquam
-          quis elit vitae, congue viverra libero.
+	The telemetry module (if enabled by the cluster administrator) sends anonymous data about the cluster back to the Ceph developers to understand how Ceph is used and to understand the problems that users might experience.
         </p>
-        <h3 class="h3">Lorem ipsum</h3>
-        <p class="mb-0 p">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in dui sed arcu ullamcorper rhoncus. Maecenas lacus ligula, aliquam
-          quis elit vitae, congue viverra libero.
-        </p>
+        <p class="mb-8 lg:mb-12 p">
+	Click the button below to see the Ceph Public Telemetry Dashboard. The telemetry dashboard summarizes information about all Ceph clusters that have opted to share anonymized data. This information includes cluster size, Ceph version, which Ceph services are enabled, and which types of storage devices are in use (categorized by their vendors and models).
+	</p>
+        <a class="button" href="https://telemetry-public.ceph.com/">Ceph Public Telemetry Dashboard</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a link to the Ceph Public Telemetry
Dashboard to the Users page. It also links to the
documentation and cleans up the marketing-speak
that was present previously.

Signed-off-by: Zac Dover <zac.dover@gmail.com>