### PR TITLE
doc/cephio: add users->documentation

### DIFF
--- a/src/en/users/documentation/index.html
+++ b/src/en/users/documentation/index.html
@@ -3,4 +3,31 @@ title: Documentation
 order: 2
 ---
 
-<h1 class="h1">{{ title }}</h1>
+<h1 class="h1">{{ title }}</h1><div>
+
+	<section class="section">
+		  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+
+        <p class="standout">
+          The Ceph Foundation believes that all storage problems should be solvable with open-source software.
+        </p>
+	<div class="bg-grey-300 p-5 rounded-2">
+	<p class="p">
+	The upstream Ceph documentation is linked below.
+	</p>
+	<p class="p">
+	The Ceph Install Guide describes how to deploy a Ceph cluster. The
+	cephadm guide describes how to use the cephadm utility to manage your
+	Ceph cluster. If you are consulting the documentation to learn the
+	rules and customs that govern making a pull request against the
+	ceph/ceph Github repository, read the Developer Guide. For more
+	in-depth information about the nature of Ceph, see the Architecture
+	Guide on the page linked below. 
+	</p>
+	<p class="p">
+	Once you are on the Ceph documentation site, use the left pane to
+	navigate to the guide you want. 
+	</p>
+        <a class="button" href="https://docs.ceph.com/">Ceph Documentation</a>
+      </div>
+	</section>


### PR DESCRIPTION
This PR adds text to the Users->Documentation
page.

Signed-off-by: Zac Dover <zac.dover@gmail.com>