### PR TITLE
Optimise search index

### DIFF
--- a/scripts/search-index.js
+++ b/scripts/search-index.js
@@ -15,10 +15,10 @@ function getData(distDir) {
 }
 
 function buildIndex(articles = []) {
-  let searchIndex = lunr(function () {
+  const searchIndex = lunr(function () {
     this.ref('id');
-    this.field('title');
-    this.field('author');
+    this.field('title', { boost: 10 });
+    this.field('author', { boost: 5 });
     this.field('content');
 
     articles.forEach((article, searchIndex) => {

--- a/scripts/search-index.js
+++ b/scripts/search-index.js
@@ -19,13 +19,12 @@ function buildIndex(articles = []) {
     this.ref('id');
     this.field('title');
     this.field('author');
-    this.field('date');
     this.field('content');
 
-    articles.forEach(function (article, searchIndex) {
+    articles.forEach((article, searchIndex) => {
       article.id = searchIndex;
       this.add(article);
-    }, this);
+    });
   });
 
   return searchIndex;

--- a/src/_11ty/filters/cleanSearchRaw.js
+++ b/src/_11ty/filters/cleanSearchRaw.js
@@ -11,11 +11,6 @@ module.exports = function (text) {
   const html = /(&lt;.*?&gt;)|(<.*?>)/gi;
   const plain = unescape(content.replace(html, ''));
 
-  // remove duplicated words
-  const words = plain.split(' ');
-  const deduped = [...new Set(words)];
-  const result = deduped.join(' ');
-
   const shortWords =
     /\b(the|a|an|and|am|you|I|to|if|of|off|me|my|on|in|it|is|at|as|we|do|be|has|but|was|so|no|not|or|up|for|ve|ll|re|s)\b/gi;
   const unicode = /[\u0000-\u001F\u007F-\u009F]/g;
@@ -23,7 +18,7 @@ module.exports = function (text) {
   const lineBreaks = /[\r\n]+/gm;
   const extraSpaces = /\s+/g;
 
-  return result
+  return plain
     .replace(shortWords, ' ')
     .replace(unicode, ' ')
     .replace(punctuation, ' ')

--- a/src/_11ty/filters/cleanSearchRaw.js
+++ b/src/_11ty/filters/cleanSearchRaw.js
@@ -4,7 +4,7 @@
  * @param {String} text
  */
 
-module.exports = function (text) {
+module.exports = function (text = '') {
   const content = new String(text).toLowerCase();
 
   // remove all html elements and new lines
@@ -14,7 +14,7 @@ module.exports = function (text) {
   const shortWords =
     /\b(the|a|an|and|am|you|I|to|if|of|off|me|my|on|in|it|is|at|as|we|do|be|has|but|was|so|no|not|or|up|for|ve|ll|re|s)\b/gi;
   const unicode = /[\u0000-\u001F\u007F-\u009F]/g;
-  const punctuation = /[!“”‘’"#$%&'()*+,–./\\:;<=>?@[\]^_`{|}~¶]/g;
+  const punctuation = /[!“”‘’"#$%&'()*+,./\\:;<=>?@[\]^_`{|}~¶]/g;
   const lineBreaks = /[\r\n]+/gm;
   const extraSpaces = /\s+/g;
 

--- a/src/_11ty/filters/cleanSearchRaw.js
+++ b/src/_11ty/filters/cleanSearchRaw.js
@@ -5,10 +5,7 @@
  */
 
 module.exports = function (text) {
-  var content = new String(text);
-
-  // all lower case
-  var content = content.toLowerCase();
+  const content = new String(text).toLowerCase();
 
   // remove all html elements and new lines
   const html = /(&lt;.*?&gt;)|(<.*?>)/gi;
@@ -19,16 +16,17 @@ module.exports = function (text) {
   const deduped = [...new Set(words)];
   const result = deduped.join(' ');
 
-  const shortWords = /\b(the|a|an|and|am|you|I|to|if|of|off|me|my|on|in|it|is|at|as|we|do|be|has|but|was|so|no|not|or|up|for|ve|ll|re|s)\b/gi;
+  const shortWords =
+    /\b(the|a|an|and|am|you|I|to|if|of|off|me|my|on|in|it|is|at|as|we|do|be|has|but|was|so|no|not|or|up|for|ve|ll|re|s)\b/gi;
   const unicode = /[\u0000-\u001F\u007F-\u009F]/g;
   const punctuation = /[!“”‘’"#$%&'()*+,–./\\:;<=>?@[\]^_`{|}~¶]/g;
   const lineBreaks = /[\r\n]+/gm;
   const extraSpaces = /\s+/g;
 
   return result
-    .replace(shortWords, '')
-    .replace(unicode, '')
-    .replace(punctuation, '')
+    .replace(shortWords, ' ')
+    .replace(unicode, ' ')
+    .replace(punctuation, ' ')
     .replace(lineBreaks, ' ')
     .replace(extraSpaces, ' ');
 };

--- a/src/_data/i18n/index.js
+++ b/src/_data/i18n/index.js
@@ -27,6 +27,9 @@ module.exports = {
   keep_reading: {
     en: 'Keep reading',
   },
+  loading: {
+    en: 'Loading…',
+  },
   next: {
     en: 'Next',
   },
@@ -85,8 +88,14 @@ module.exports = {
   'blog-post': {
     en: 'Blog',
   },
+  blog_search_failed: {
+    en: 'Sorry, we couldn’t complete your search at this time. Please try again shortly.',
+  },
   blog_search_no_results: {
     en: 'No results for',
+  },
+  blog_search_unavailable: {
+    en: 'Please enable JavaScript to search',
   },
   blog_searched_for: {
     en: 'You searched for',

--- a/src/_includes/layouts/_base.njk
+++ b/src/_includes/layouts/_base.njk
@@ -25,7 +25,7 @@
         - its translationKey matches the current item translationKey
         - its locale matches the code of the language we are looping through #}
         {%- if item.data.translationKey == translationKey and item.data.locale == lang.code -%}
-          <link rel="alternate" hreflang="{{ item.data.locale }}" href="{{ item.url }}" />
+          <link rel="alternate" hreflang="{{ item.data.locale }}" href="{{ item.url }}"/>
         {%- endif -%}
 
       {%- endfor -%}
@@ -36,6 +36,9 @@
     <link rel="canonical" href="{{ site.url }}{{ page.url }}">
 
     {# Preload/dns-prefetch #}
+    {% for link in preload -%}
+      <link rel="preload" href="{{link.href}}" as="{{link.as}}"/>
+    {%- endfor -%}
 
     {# Stylesheet #}
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -58,7 +61,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon-180x180.png">
 
     <link rel="mask-icon" href="/assets/favicons/safari-pinned-tab.svg" color="#f0424d">
-    
+
     <link rel="manifest" href="/assets/favicons/manifest.json">
 
     {# Robots #}
@@ -68,17 +71,17 @@
 
     {# Social meta #}
     <meta property="og:locale" content="{{ locale }}">
-    <meta property="og:title" content="{% if title %}{{ title }} - {% endif %}{{ site.title }}" />
-    <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="{% if image %}{{ image }}{% else %}https://via.placeholder.com/640x360{% endif %}" />
+    <meta property="og:title" content="{% if title %}{{ title }} - {% endif %}{{ site.title }}"/>
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:image" content="{% if image %}{{ image }}{% else %}https://via.placeholder.com/640x360{% endif %}"/>
     <meta property="og:site_name" content="{{ site.title }}">
 
-    <meta name="twitter:card" content="{% if image %}summary_large_image{% else %}summary{% endif %}" />
-    <meta name="twitter:site" content="{{ social.twitter }}" />
-    <meta name="twitter:title" content="{% if title %}{{ title }} - {% endif %}{{ site.title }}" />
-    <meta name="twitter:url" content="{{ site.url }}{{ page.url }}" />
-    <meta name="twitter:image" content="{% if image %}{{ image }}{% else %}https://via.placeholder.com/640x360{% endif %}" />
+    <meta name="twitter:card" content="{% if image %}summary_large_image{% else %}summary{% endif %}"/>
+    <meta name="twitter:site" content="{{ social.twitter }}"/>
+    <meta name="twitter:title" content="{% if title %}{{ title }} - {% endif %}{{ site.title }}"/>
+    <meta name="twitter:url" content="{{ site.url }}{{ page.url }}"/>
+    <meta name="twitter:image" content="{% if image %}{{ image }}{% else %}https://via.placeholder.com/640x360{% endif %}"/>
 
   </head>
   <body class={{layout}}>

--- a/src/_includes/layouts/listing-blog-search.njk
+++ b/src/_includes/layouts/listing-blog-search.njk
@@ -1,6 +1,11 @@
 ---
 layout: navigation
 permalink: '/{{ locale }}/news/blog/search/'
+preload:
+  - href: ../search-index.json
+    as: fetch
+  - href: ../search-output.json
+    as: fetch
 ---
 
 {% set blogPostLocaleTag = locale + '-blog-post' %}

--- a/src/_includes/layouts/listing-blog-search.njk
+++ b/src/_includes/layouts/listing-blog-search.njk
@@ -12,52 +12,61 @@ permalink: '/{{ locale }}/news/blog/search/'
     <h1 class="h1 mb-0">{{ title }}</h1>
     <div class="grid md:grid--cols-2">
       <div>
-      <select class="select w-full" id="filters" onchange="javascript:location.href = this.value;">
-        <option value="">{{ 'filter_by_topic' | i18n }}</option>
-        {% for item in blogPostFilters %}
-          {% set itemSlug = item | slug + '/'%}
-          <option {% if page.url | endsWith(itemSlug) %}selected{% endif %} value="/{{ locale }}/news/blog/category/{{ itemSlug }}">
-            {{ item }}</a>
+        <select class="select w-full" id="filters" onchange="javascript:location.href = this.value;">
+          <option value="">{{ 'filter_by_topic' | i18n }}</option>
+          {% for item in blogPostFilters %}
+            {% set itemSlug = item | slug + '/'%}
+            <option {% if page.url | endsWith(itemSlug) %}selected{% endif %} value="/{{ locale }}/news/blog/category/{{ itemSlug }}">
+              {{ item }}</a>
           </option>
         {% endfor %}
       </select>
-      </div>
-      <form action="/{{ locale }}/news/blog/search/" class="relative" method="get">
-        <input aria-label="Search" class="input w-full" id="search-str" name="q" placeholder="{{ 'search_all_blog_posts' | i18n }}" required type="search" />
-        <button class="input" id="search-reset" type="reset">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <g fill="none" fill-rule="evenodd" stroke="#0a0c38" stroke-linecap="square" stroke-width="2">
-              <path d="M16 8l-8 8M16 16L8 8"/>
-            </g>
-          </svg>
-          <span class="visually-hidden">Reset search</span>
-        </button>
-        <button class="input" id="search-submit" type="submit">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="#0a0c38">
-            <path d="M16.294 14.579h-.903l-.32-.31a7.4 7.4 0 001.795-4.836 7.433 7.433 0 10-7.433 7.433 7.4 7.4 0 004.837-1.796l.309.32v.904L20.296 22 22 20.296l-5.706-5.717zm-6.861 0a5.139 5.139 0 01-5.146-5.146 5.139 5.139 0 015.146-5.146 5.139 5.139 0 015.146 5.146 5.139 5.139 0 01-5.146 5.146z"/>
-          </svg>
-          <span class="visually-hidden">Submit search</span>
-        </button>
-      </form>
     </div>
+    <form action="/{{ locale }}/news/blog/search/" class="relative" method="get">
+      <input aria-label="Search" class="input w-full" id="search-str" name="q" placeholder="{{ 'search_all_blog_posts' | i18n }}" required type="search"/>
+      <button class="input" id="search-reset" type="reset">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <g fill="none" fill-rule="evenodd" stroke="#0a0c38" stroke-linecap="square" stroke-width="2">
+            <path d="M16 8l-8 8M16 16L8 8"/>
+          </g>
+        </svg>
+        <span class="visually-hidden">Reset search</span>
+      </button>
+      <button class="input" id="search-submit" type="submit">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="#0a0c38">
+          <path d="M16.294 14.579h-.903l-.32-.31a7.4 7.4 0 001.795-4.836 7.433 7.433 0 10-7.433 7.433 7.4 7.4 0 004.837-1.796l.309.32v.904L20.296 22 22 20.296l-5.706-5.717zm-6.861 0a5.139 5.139 0 01-5.146-5.146 5.139 5.139 0 015.146-5.146 5.139 5.139 0 015.146 5.146 5.139 5.139 0 01-5.146 5.146z"/>
+        </svg>
+        <span class="visually-hidden">Submit search</span>
+      </button>
+    </form>
   </div>
+</div>
 
-  <div class="min-h-80" id="search-results"></div>
+<div class="min-h-80" id="search-results">
+  <p class="h3 mb-8 xl:mb-10">
+    <span class="hide-no-js">
+      {{ 'loading' | i18n }}
+    </span>
+    <span class="hide-js">
+      {{ 'blog_search_unavailable' | i18n }}
+    </span>
+  </p>
+</div>
 </section>
 
 <section class="pt-0 section">
-  <div class="bg-grey-300 border-grey-500 border-px border-solid p-5 rounded-2">
-    <div class="flex flex--align-center flex--gap-6 flex--justify-between flex--wrap">
-      <div>
-        <h2 class="h3">Subscribe to Ceph Announcements</h2>
-        <p class="p">Ned placerat est a augue pulvinar imperdiet quis in setiam euismod.</p>
-        <a class="a" href="#">Other ways to stay connected</a>
-      </div>
-      <div>
-        <a class="button" href="#">Subscribe to Ceph Announcements</a>
-      </div>
+<div class="bg-grey-300 border-grey-500 border-px border-solid p-5 rounded-2">
+  <div class="flex flex--align-center flex--gap-6 flex--justify-between flex--wrap">
+    <div>
+      <h2 class="h3">Subscribe to Ceph Announcements</h2>
+      <p class="p">Ned placerat est a augue pulvinar imperdiet quis in setiam euismod.</p>
+      <a class="a" href="#">Other ways to stay connected</a>
+    </div>
+    <div>
+      <a class="button" href="#">Subscribe to Ceph Announcements</a>
     </div>
   </div>
+</div>
 </section>
 
 {{ content | safe }}

--- a/src/css/utilities.display.css
+++ b/src/css/utilities.display.css
@@ -40,3 +40,8 @@
     display: none;
   }
 }
+
+.js .hide-js,
+.no-js .hide-no-js {
+  display: none;
+}

--- a/src/en/news/blog/search-raw.html
+++ b/src/en/news/blog/search-raw.html
@@ -5,5 +5,5 @@ override:tags: []
 eleventyExcludeFromCollections: true
 ---
 
-[ {% for item in collections['en-blog-post'] %} { "title":"{{item.data.title}}", "author":"{{item.data.author}}",
-"date":"{{item.data.date}}", "content":"{{ item.templateContent | cleanSearchRaw }}" }{% if loop.last != true %},{% endif %} {% endfor %} ]
+[ {% for item in collections['en-blog-post'] %} { "title":"{{ item.data.title }}", "author":"{{ item.data.author }}", "content":"{{
+item.templateContent | cleanSearchRaw }}" }{% if loop.last != true %},{% endif %} {% endfor %} ]

--- a/src/js/search-output.js
+++ b/src/js/search-output.js
@@ -24,7 +24,13 @@ const SearchOutput = {
         searchInput.value = query;
 
         const [searchIndex, searchOutput] = await Promise.all(
-          searchDataUrls.map(url => fetch(url).then(res => res.json()))
+          searchDataUrls.map(url =>
+            fetch(url, {
+              method: 'GET',
+              credentials: 'include',
+              mode: 'no-cors',
+            }).then(res => res.json())
+          )
         );
         const lunrIndex = lunr.Index.load(searchIndex);
 

--- a/src/js/search-output.js
+++ b/src/js/search-output.js
@@ -4,9 +4,13 @@ import translations from '../_data/i18n';
 
 const SearchOutput = {
   init: () => {
-    console.log(translations);
-    const urlPath = window.location.pathname.split('/');
-    const urlLocale = urlPath[1];
+    const urlParts = window.location.pathname.split('/') || [];
+    const urlLocale = urlParts[1];
+    const blogDir = `/${urlLocale}/news/blog`;
+    const searchDataUrls = [
+      `${blogDir}/search-index.json`,
+      `${blogDir}/search-output.json`,
+    ];
     const searchInput = document.getElementById('search-str');
     const searchresultsContainer = document.getElementById('search-results');
     const queryString = window.location.search;
@@ -14,24 +18,24 @@ const SearchOutput = {
     const query = urlParams.get('q');
 
     async function initSearchIndex() {
-      const searchIndexData = await fetch(
-        `/${urlLocale}/news/blog/search-index.json`
-      );
-      const index = await searchIndexData.json();
-      const lunrIndex = lunr.Index.load(index);
-
-      const searchOutputData = await fetch(
-        `/${urlLocale}/news/blog/search-output.json`
-      );
-      const output = await searchOutputData.json();
-
       if (!urlParams.has('q')) return;
-      search(lunrIndex, query, output);
+
+      try {
+        searchInput.value = query;
+
+        const [searchIndex, searchOutput] = await Promise.all(
+          searchDataUrls.map(url => fetch(url).then(res => res.json()))
+        );
+        const lunrIndex = lunr.Index.load(searchIndex);
+
+        search(lunrIndex, searchOutput);
+      } catch (error) {
+        console.error(error);
+        renderError();
+      }
     }
 
-    function search(lunrIndex, searchQuery, searchOutput) {
-      searchInput.value = searchQuery;
-
+    function search(lunrIndex, searchOutput) {
       let searchResults = lunrIndex.search(query);
 
       searchResults.forEach(result => {
@@ -43,30 +47,27 @@ const SearchOutput = {
         result.content = searchOutput[result.ref].content;
       });
 
-      renderResults(searchResults, searchQuery);
+      renderResults(searchResults);
     }
 
-    function renderResults(results = [], searchQuery) {
+    function renderResults(results = []) {
       let searchResultsHtml;
 
-      const { blog_search_no_results = {} } = translations || {};
+      const { blog_search_no_results = {}, blog_searched_for = {} } =
+        translations || {};
       const noResultsString =
         blog_search_no_results[urlLocale] || 'No results for';
-
-      const { blog_searched_for = {} } = translations || {};
       const searchedForString =
         blog_searched_for[urlLocale] || 'You searched for';
 
       if (!searchresultsContainer) return;
 
       if (!results.length) {
-        searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${noResultsString} “${searchQuery}”</p>`;
+        searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${noResultsString} “${query}”</p>`;
       } else {
-        searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${searchedForString} “${searchQuery}”</p>
+        searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${searchedForString} “${query}”</p>
       <ul class="grid md:grid--cols-2 lg:grid--cols-3 xl:grid--cols-4 list-none m-0 p-0">${results
-        .map(result => {
-          const { author, content, date, image, title, url } = result;
-
+        .map(({ author, content, date, image, title, url }) => {
           const restucturedData = {
             data: {
               author,
@@ -83,6 +84,17 @@ const SearchOutput = {
         })
         .join('')}</ul>`;
       }
+
+      searchresultsContainer.innerHTML = searchResultsHtml;
+    }
+
+    function renderError() {
+      const { blog_search_failed = {} } = translations || {};
+      const errorMessage =
+        blog_search_failed[urlLocale] ||
+        'Sorry, we couldn’t complete your search at this time. Please try again shortly.';
+
+      const searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${errorMessage}</p>`;
 
       searchresultsContainer.innerHTML = searchResultsHtml;
     }


### PR DESCRIPTION
- Remove `date` — not sure this field (given it's an ISO date it's not particularly searchable anyway)
- Use spaces instead of empty strings for `shortWords`, `unicode` and `punctuation` replacements. With these as empty strings we were seeing a lot of accidentally combined words in the index, especially in indexed code snippets (e.g. `radosopenpoolconst`). When these are properly separated, the quality of the index actually improves (more keywords), and the size greatly decreases due to compression.
- Removed the `dedupe`ing — this doesn't actually have a great impact on the final index size (due to compression), and may actually decrease the quality of results, as the pages with search terms frequently repeated should rank higher.
- Added `boost` param for `title` and `author` fields, as this also improves relevance of results.

So in total, it takes us from an index of 11MB (2.04MB gzip) to 7.6MB (1.63MB gzip), down ~20% compressed.

Note: Tried a few other tactics for reducing the search index size without impacting the quality of the results. For example, tried omitting long words (e.g. >= 15 characters, which were often a side-effect of splitting/replacing strings in the content) and long number strings (e.g. `1000000`). Because of gzip compression and the repeptitiveness of these strings, it didn't improve the filesize enough to warrant the complexity it introduced to `cleanSearchRaw`.

👀 Also refactored `SearchOutput` slightly, to add error handling and error state, parallelize requests for JSON.