### PR TITLE
Updated blog listing pagination order so newest appear first

### DIFF
--- a/src/_includes/layouts/listing-blog-posts.njk
+++ b/src/_includes/layouts/listing-blog-posts.njk
@@ -2,6 +2,7 @@
   layout: navigation
   pagination:
     size: 12
+    reverse: true
   permalink: '/{{ locale }}/news/blog{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber + 1}}{% endif %}/index.html'
 ---
 


### PR DESCRIPTION
A very simple code tweak but worth checking it locally to make sure it's working as expected.

Newest blog posts should be appearing first.

Closes #128 