### PR TITLE
Fix date formatting off-by-one bug

### DIFF
--- a/src/_11ty/filters/formatDate.js
+++ b/src/_11ty/filters/formatDate.js
@@ -12,5 +12,5 @@ module.exports = (date, locale = defaultLocale) => {
     // hour12: false,
     // timeZone: 'UTC',
     // timeZoneName: 'short'
-  }).format(new Date(date));
+  }).format(new Date(date).toUTCString());
 };

--- a/src/_11ty/filters/formatDate.js
+++ b/src/_11ty/filters/formatDate.js
@@ -2,15 +2,12 @@ const site = require('../../_data/site');
 const { defaultLocale } = site;
 
 module.exports = (date, locale = defaultLocale) => {
-  // May need to consider `timezone` option (defaults to UTC)
-  return new Intl.DateTimeFormat(locale, {
+  const format = new Intl.DateTimeFormat(locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-    // hour: 'numeric',
-    // minute: 'numeric'
-    // hour12: false,
-    // timeZone: 'UTC',
-    // timeZoneName: 'short'
+    timeZone: 'UTC',
   }).format(new Date(new Date(date).toUTCString()));
+  console.log(date, format);
+  return format;
 };

--- a/src/_11ty/filters/formatDate.js
+++ b/src/_11ty/filters/formatDate.js
@@ -2,12 +2,11 @@ const site = require('../../_data/site');
 const { defaultLocale } = site;
 
 module.exports = (date, locale = defaultLocale) => {
-  const format = new Intl.DateTimeFormat(locale, {
+  return new Intl.DateTimeFormat(locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     timeZone: 'UTC',
   }).format(new Date(new Date(date).toUTCString()));
-  console.log(date, format);
   return format;
 };

--- a/src/_11ty/filters/formatDate.js
+++ b/src/_11ty/filters/formatDate.js
@@ -6,7 +6,8 @@ module.exports = (date, locale = defaultLocale) => {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    // Dates should be converted to UTC to avoid off-by-one issues
+    // See docs: https://www.11ty.dev/docs/dates/#dates-off-by-one-day
     timeZone: 'UTC',
   }).format(new Date(new Date(date).toUTCString()));
-  return format;
 };

--- a/src/_11ty/filters/formatDate.js
+++ b/src/_11ty/filters/formatDate.js
@@ -12,5 +12,5 @@ module.exports = (date, locale = defaultLocale) => {
     // hour12: false,
     // timeZone: 'UTC',
     // timeZoneName: 'short'
-  }).format(new Date(date).toUTCString());
+  }).format(new Date(new Date(date).toUTCString()));
 };

--- a/src/_11ty/filters/formatDate.js
+++ b/src/_11ty/filters/formatDate.js
@@ -9,5 +9,5 @@ module.exports = (date, locale = defaultLocale) => {
     // Dates should be converted to UTC to avoid off-by-one issues
     // See docs: https://www.11ty.dev/docs/dates/#dates-off-by-one-day
     timeZone: 'UTC',
-  }).format(new Date(new Date(date).toUTCString()));
+  }).format(new Date(date));
 };

--- a/src/_11ty/filters/formatDateRange.js
+++ b/src/_11ty/filters/formatDateRange.js
@@ -20,8 +20,5 @@ module.exports = (date, end, locale = defaultLocale) => {
     // Dates should be converted to UTC to avoid off-by-one issues
     // See docs: https://www.11ty.dev/docs/dates/#dates-off-by-one-day
     timeZone: 'UTC',
-  }).formatRange(
-    new Date(new Date(date).toUTCString()),
-    new Date(new Date(endDate).toUTCString())
-  );
+  }).formatRange(new Date(date), new Date(endDate));
 };

--- a/src/_11ty/filters/formatDateRange.js
+++ b/src/_11ty/filters/formatDateRange.js
@@ -17,5 +17,11 @@ module.exports = (date, end, locale = defaultLocale) => {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-  }).formatRange(date, endDate);
+    // Dates should be converted to UTC to avoid off-by-one issues
+    // See docs: https://www.11ty.dev/docs/dates/#dates-off-by-one-day
+    timeZone: 'UTC',
+  }).formatRange(
+    new Date(new Date(date).toUTCString()),
+    new Date(new Date(endDate).toUTCString())
+  );
 };


### PR DESCRIPTION
We had this earmarked as something potentially needing attention, but hadn't realised the issue caused on the build server.

By ensuring we set `timeZone` (now in sync with [server timezone](https://github.com/ceph/ceph.io/issues/241#issuecomment-871685879)) to `UTC` and we `toUTCString()` any date coming to `formatDate()`, we ensure that dates avoid the off-by-one issue.

This should cover data-driven content dates across the site (blogs, press releases, events, tech talks).

Tested on branch deploy, and dates are as per data:
- https://241-utc-dates.ceph.io/en/news/blog/2021/v14-2-22-nautilus-released/
- https://241-utc-dates.ceph.io/en/community/tech-talks/
- https://241-utc-dates.ceph.io/en/community/events/2019/cephalocon-barcelona/

Closes #239
Fixes #241 