### PR TITLE
Draft: Optimise Matomo script usage

### DIFF
--- a/src/_includes/layouts/_base.njk
+++ b/src/_includes/layouts/_base.njk
@@ -40,12 +40,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
+    <link rel="preconnect" href="https://cdn.matomo.cloud">
+    <link rel="preconnect" href="https://ceph.matomo.cloud">
+
     {% for link in preload -%}
       <link rel="preload" href="{{link.href}}" as="{{link.as}}"/>
     {%- endfor -%}
-
-    <link rel="dns-prefetch" href="https://cdn.matomo.cloud">
-    <link rel="dns-prefetch" href="https://ceph.matomo.cloud">
 
     {# Stylesheet #}
     <link rel="stylesheet" href="/css/main.css"/>

--- a/src/_includes/layouts/_base.njk
+++ b/src/_includes/layouts/_base.njk
@@ -40,12 +40,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-    <link rel="preconnect" href="https://cdn.matomo.cloud">
-    <link rel="preconnect" href="https://ceph.matomo.cloud">
-
     {% for link in preload -%}
       <link rel="preload" href="{{link.href}}" as="{{link.as}}"/>
     {%- endfor -%}
+
+    <link rel="dns-prefetch" href="https://ceph.matomo.cloud">
 
     {# Stylesheet #}
     <link rel="stylesheet" href="/css/main.css"/>

--- a/src/_includes/layouts/_base.njk
+++ b/src/_includes/layouts/_base.njk
@@ -15,7 +15,7 @@
     </script>
 
     <title>Ceph.io — {{ title }}</title>
-    <meta name="description" content="{{ meta.description }}" />
+    <meta name="description" content="{{ meta.description }}"/>
 
     {% for lang in locales -%}
 
@@ -43,6 +43,9 @@
     {% for link in preload -%}
       <link rel="preload" href="{{link.href}}" as="{{link.as}}"/>
     {%- endfor -%}
+
+    <link rel="dns-prefetch" href="https://cdn.matomo.cloud">
+    <link rel="dns-prefetch" href="https://ceph.matomo.cloud">
 
     {# Stylesheet #}
     <link rel="stylesheet" href="/css/main.css"/>
@@ -101,15 +104,25 @@
       _paq.push(["setCookieDomain", "*.ceph.io"]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
-      (function() {
-	  var u="https://ceph.matomo.cloud/";
-	  _paq.push(['setTrackerUrl', u+'matomo.php']);
-	  _paq.push(['setSiteId', '1']);
-	  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-	  g.async=true; g.src='//cdn.matomo.cloud/ceph.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      (function () {
+        var u = "https://ceph.matomo.cloud/";
+        _paq.push([
+          'setTrackerUrl', u + 'matomo.php'
+        ]);
+        _paq.push(['setSiteId', '1']);
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = '//cdn.matomo.cloud/ceph.matomo.cloud/matomo.js';
+        s
+          .parentNode
+          .insertBefore(g, s);
       })();
     </script>
-    <noscript><p><img src="https://ceph.matomo.cloud/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+    <noscript>
+      <p><img src="https://ceph.matomo.cloud/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt=""/></p>
+    </noscript>
     <!-- End Matomo Code -->
 
   </head>


### PR DESCRIPTION
Following the addition of Matomo analytics (#257).

We can add `dns-prefetch` for Matomo domains to optimise the loading of the two scripts it requests. This is a [recommended](https://matomo.org/blog/2017/04/important-performance-optimizations-load-piwik-javascript-tracker-faster/) performance update to ensure scripts are loaded effectively. Expect it'll shave ~0.5s off tracking initialisation based on [baseline](https://www.webpagetest.org/result/210817_BiDc4A_86bbb9e1e0b82007fd670750d2b47e53/1/details/#waterfall_view_step1) performance. Will run performance test to confirm before merging.

Note: Some minor auto-reformatting of the `_base.njk` file, not affecting the script functionality (owing to Prettier. This will all be minified away in production regardless).