### PR TITLE
Adds links to Ceph guides for beginngers to Developer resources page

### DIFF
--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -217,3 +217,23 @@ overlaySubMenu: true
     </ul>
   </div>
 </section>
+
+<hr class="hr" />
+
+<section class="section">
+  <h2 class="h2 mb-12 lg:mb-16">Ceph guides, tips and tricks</h2>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        Just getting started, or looking for some tips on implementing solutions for specific use cases with Ceph? We've collected some curated, downloadable guides to assist you as you explore the vast configurability and flexibility Ceph has to offer.
+      </p>
+    </div>
+    <div>
+      <h3 class="h3">Ceph basics</h3>
+      <ul>
+        <li><a href="https://bit.ly/Top10CephCommands">Ten essential Ceph commands to manage your cluster</a></li>
+		<li><a href="https://bit.ly/5CephMistakesToAvoid"></a>Top five mistakes to avoid in your Ceph storage cluster</li>
+      </ul>
+    </div>
+  </div>
+</section>

--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -218,8 +218,6 @@ overlaySubMenu: true
   </div>
 </section>
 
-<hr class="hr" />
-
 <section class="section">
   <h2 class="h2 mb-12 lg:mb-16">Ceph guides, tips and tricks</h2>
   <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
@@ -230,9 +228,17 @@ overlaySubMenu: true
     </div>
     <div>
       <h3 class="h3">Ceph basics</h3>
-      <ul>
-        <li><a href="https://bit.ly/Top10CephCommands">Ten essential Ceph commands to manage your cluster</a></li>
-		<li><a href="https://bit.ly/5CephMistakesToAvoid"></a>Top five mistakes to avoid in your Ceph storage cluster</li>
+      <ul class="ul">
+        <li>
+          <a class="a" href="https://bit.ly/Top10CephCommands" target="_blank" rel="noreferrer noopener"
+            >Ten essential Ceph commands to manage your cluster</a
+          >
+        </li>
+        <li>
+          <a class="a" href="https://bit.ly/5CephMistakesToAvoid" target="_blank" rel="noreferrer noopener"
+            >Top five mistakes to avoid in your Ceph storage cluster</a
+          >
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
* appends new 2-column section to the end of the developer resources page, for linking to downloadable Ceph how-tos / guides for beginners
* adds brief blurb for this section
* adds two links to Ceph guides in the new section

Signed-off by Wendy White <wendy@fishoutoforder.net>