### PR TITLE
Addresses display issues on Developers page

### DIFF
--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -65,8 +65,7 @@ overlaySubMenu: true
               community.
             </p>
             <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/start/intro/"
-              >Get started with Ceph (documentation)</a
-            >
+              >Get started with Ceph (documentation)</a>
           </div>
         </div>
       </li>
@@ -230,14 +229,10 @@ overlaySubMenu: true
       <h3 class="h3">Ceph basics</h3>
       <ul class="ul">
         <li>
-          <a class="a" href="https://bit.ly/Top10CephCommands" target="_blank" rel="noreferrer noopener"
-            >Ten essential Ceph commands to manage your cluster</a
-          >
+          <a class="a" href="https://bit.ly/Top10CephCommands" target="_blank" rel="noreferrer noopener">Ten essential Ceph commands to manage your cluster</a>
         </li>
         <li>
-          <a class="a" href="https://bit.ly/5CephMistakesToAvoid" target="_blank" rel="noreferrer noopener"
-            >Top five mistakes to avoid in your Ceph storage cluster</a
-          >
+          <a class="a" href="https://bit.ly/5CephMistakesToAvoid" target="_blank" rel="noreferrer noopener"> Top five mistakes to avoid in your Ceph storage cluster</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
One section on the Developers page are not displaying quite correctly (not rendering on the page) due to line breaks added in #287. Commits to this branch are intended to fix this. 

Signed-off by Wendy White <wendy@fishoutoforder.net>