### PR TITLE
Add titles to Cephalocon and meetup

### DIFF
--- a/src/en/community/events/2021/meetup-dach-2021-11-30/index.md
+++ b/src/en/community/events/2021/meetup-dach-2021-11-30/index.md
@@ -1,4 +1,5 @@
 ---
+title: Ceph Meetup
 date: 2021-11-30
 end: 2021-11-30
 location: Virtual

--- a/src/en/community/events/2022/cephalocon-portland/index.md
+++ b/src/en/community/events/2022/cephalocon-portland/index.md
@@ -1,4 +1,5 @@
 ---
+title: Cephalocon 2022
 date: 2022-04-05
 end: 2022-04-07
 location: Portland, Oregon + Virtual


### PR DESCRIPTION
Adding the missing `title` field to frontmatter for the most recent to events, including the upcoming Cephalocon 2022.

This ensures that the event listing and event pages have proper headings in the page content, consistent with other previous events.

<img width="1626" alt="Screenshot 2021-12-15 at 08 15 17" src="https://user-images.githubusercontent.com/2671053/146148898-00c5bdaf-bfb2-4333-bf56-10a39186834d.png">

The specs for collections (like events, blog posts, etc.) are captured in their respective directories in the solution for more info: [Events README](https://github.com/ceph/ceph.io/tree/main/src/en/community/events#readme)