### PR TITLE
doc: updating broken PDF link

### DIFF
--- a/src/en/discover/technology/index.html
+++ b/src/en/discover/technology/index.html
@@ -241,7 +241,7 @@ overlaySubMenu: true
           <a class="a" href="https://docs.ceph.com/en/latest/rados/">RADOS documentation (docs.ceph.com)</a>
         </li>
         <li>
-          <a class="a" href="https://ceph.com/wp-content/uploads/2016/08/weil-rados-pdsw07.pdf"
+          <a class="a" href="https://ceph.com/assets/pdfs/weil-rados-pdsw07.pdf"
             >RADOS: A Scalable, Reliable Storage Service for Petabyte-scale Storage Clusters (academic paper)</a
           >
         </li>


### PR DESCRIPTION
This updates a broken PDF link to a working PDF link.

On the page
https://ceph.com/en/discover/technology/

the following URL has been updated:
 https://ceph.com/wp-content/uploads/2016/08/weil-rados-pdsw07.pdf returns 404 not found.

The above URL has been updated to the following URL:

https://ceph.com/assets/pdfs/weil-rados-pdsw07.pdf

I have not confirmed locally that this works, because my patience with
npm and nodejs has been exhausted.

Signed-off-by: Zac Dover <zac.dover@gmail.com>