### PR TITLE
users/documentation: link to latest docs

### DIFF
--- a/src/en/users/documentation/index.html
+++ b/src/en/users/documentation/index.html
@@ -16,7 +16,7 @@ order: 2
         Architecture Guide on the page linked below.
       </p>
       <p class="p">Once you are on the Ceph documentation site, use the left pane to navigate to the guide you want.</p>
-      <a class="button" href="https://docs.ceph.com/">Ceph Documentation</a>
+      <a class="button" href="https://docs.ceph.com/en/latest/">Ceph Documentation</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
As described here https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/H5UM5XKVM54XMCFJEVHBFX6TWXCKBDUU/
the link from ceph.io to docs should point to latest, so that users see which releases are currently available.