### PR TITLE
Adding tags to all release blog posts

### DIFF
--- a/src/en/news/blog/2008/v02-released/index.md
+++ b/src/en/news/blog/2008/v02-released/index.md
@@ -3,6 +3,7 @@ title: "v0.2 Released"
 date: "2008-05-07"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 The kernel client is holding up well under the latest round of testing, so I’ve cut a v0.2 release and am sending an announcement to LKML and linux-fsdevel. Notable in this release:

--- a/src/en/news/blog/2009/v010-released/index.md
+++ b/src/en/news/blog/2009/v010-released/index.md
@@ -3,6 +3,7 @@ title: "v0.10 released"
 date: "2009-07-16"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.10.  The big items this time around:

--- a/src/en/news/blog/2009/v012-released/index.md
+++ b/src/en/news/blog/2009/v012-released/index.md
@@ -3,6 +3,7 @@ title: "v0.12 released"
 date: "2009-08-05"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 I’ve just tagged a v0.12 released, and sent the kernel client patchset off to the Linux kernel and fsdevel lists again.  There was a v0.11 a week ago as well that incorporated some earlier feedback from the kernel lists.

--- a/src/en/news/blog/2009/v013-released/index.md
+++ b/src/en/news/blog/2009/v013-released/index.md
@@ -3,6 +3,7 @@ title: "v0.13 released"
 date: "2009-08-24"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve made a v0.13 release.  This mostly fixes bugs with v0.12 that have come up over the past couple weeks:

--- a/src/en/news/blog/2009/v014-released/index.md
+++ b/src/en/news/blog/2009/v014-released/index.md
@@ -3,6 +3,7 @@ title: "v0.14 released"
 date: "2009-09-08"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We”ve released v0.14.  Changes since v0.13 include:

--- a/src/en/news/blog/2009/v015-released/index.md
+++ b/src/en/news/blog/2009/v015-released/index.md
@@ -3,6 +3,7 @@ title: "v0.15 released"
 date: "2009-09-22"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.15.  This is mostly cleanups for the kernel client and some work on the monitor interface.  Changes since v0.14 include:

--- a/src/en/news/blog/2009/v016-released/index.md
+++ b/src/en/news/blog/2009/v016-released/index.md
@@ -3,6 +3,7 @@ title: "v0.16 released"
 date: "2009-10-05"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.16.  The release primarily incorporates feedback on the Linux kernel client from LKML.  Changes since v0.15 include:

--- a/src/en/news/blog/2009/v017-released/index.md
+++ b/src/en/news/blog/2009/v017-released/index.md
@@ -3,6 +3,7 @@ title: "v0.17 released"
 date: "2009-10-19"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.17.  This is mainly bug fixes and some monitor improvements.  Changes since v0.16 include:

--- a/src/en/news/blog/2009/v018-released/index.md
+++ b/src/en/news/blog/2009/v018-released/index.md
@@ -3,6 +3,7 @@ title: "v0.18 released"
 date: "2009-12-04"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 There’s a v0.18 release to match the latest posting of the kernel client code on the Linux email lists.  If there are no final issues there, that will be what I send to Linus for 2.6.33.

--- a/src/en/news/blog/2009/v08-released/index.md
+++ b/src/en/news/blog/2009/v08-released/index.md
@@ -3,6 +3,7 @@ title: "v0.8 released"
 date: "2009-05-19"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Ceph v0.8 has been released.  [Debian packages for amd64 and i386](http://ceph.newdream.net/wiki/Debian) have been built and there is a [tarball](http://ceph.newdream.net/download/), or you can [pull the ‘master’ branch from Git](http://ceph.newdream.net/wiki/Checking_out).  This update has a lot of important protocol changes and corresponding performance improvements:

--- a/src/en/news/blog/2010/v0-19-released/index.md
+++ b/src/en/news/blog/2010/v0-19-released/index.md
@@ -3,6 +3,7 @@ title: "v0.19 released"
 date: "2010-02-17"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 The v0.19 release is finally here.  The focus this past cycle was on stability and the disk format, and things have improved greatly in that area.  Our plan is to make any future disk format changes roll forward, so that users won’t need to rebuild their file systems.  The protocol has also grown feature bits that so it is at least possible to make protocol changes transparent; whether we do so or not will depend on the severity of the change and cost of maintaining compatibility.

--- a/src/en/news/blog/2010/v0-20-1-released/index.md
+++ b/src/en/news/blog/2010/v0-20-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.20.1 released"
 date: "2010-05-17"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released a stable update with a bunch of bug fixes since v0.20.  Notably, we’ve fixed

--- a/src/en/news/blog/2010/v0-20-2-released/index.md
+++ b/src/en/news/blog/2010/v0-20-2-released/index.md
@@ -3,6 +3,7 @@ title: "v0.20.2 released"
 date: "2010-05-27"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.20.2 with a few bug fixes.  These include

--- a/src/en/news/blog/2010/v0-20-released/index.md
+++ b/src/en/news/blog/2010/v0-20-released/index.md
@@ -3,6 +3,7 @@ title: "v0.20 released"
 date: "2010-04-30"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 After a long few weeks of debugging, we’re releasing v0.20.  The goal here is to get something out prior to the v2.6.34 kernel release (which includes the Ceph client) with most of the pending improvements.  Changes since v0.19 include:

--- a/src/en/news/blog/2010/v0-21-1-released/index.md
+++ b/src/en/news/blog/2010/v0-21-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.21.1 released"
 date: "2010-08-16"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve made a bugfix release for v0.21 last week.  Changes include:

--- a/src/en/news/blog/2010/v0-21-2-released/index.md
+++ b/src/en/news/blog/2010/v0-21-2-released/index.md
@@ -3,6 +3,7 @@ title: "v0.21.2 released"
 date: "2010-08-28"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This is a second bugfix release for the v0.21 series.  Changes include:

--- a/src/en/news/blog/2010/v0-21-3-released/index.md
+++ b/src/en/news/blog/2010/v0-21-3-released/index.md
@@ -3,6 +3,7 @@ title: "v0.21.3 released"
 date: "2010-09-18"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 The v0.21.3 release is out.  Changes since v0.21.2 include:

--- a/src/en/news/blog/2010/v0-21-released/index.md
+++ b/src/en/news/blog/2010/v0-21-released/index.md
@@ -3,6 +3,7 @@ title: "v0.21 released"
 date: "2010-07-29"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It’s been a while, but v0.21 is ready.  Most of the work this time around has been on stability. There is one key new feature, however: RBD, the rados block device, which let you create a virtual disk backed by objects stored in the Ceph cluster.  The images can be mapped natively by the ceph kernel module or via a driver in qemu/KVM.  Although neither of those drivers is upstream yet, the server side functionality and admin tools are in place.

--- a/src/en/news/blog/2010/v0-22-1-released/index.md
+++ b/src/en/news/blog/2010/v0-22-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.22.1 released"
 date: "2010-10-24"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This release fixes a few critical bugs in v0.22:

--- a/src/en/news/blog/2010/v0-22-2-released/index.md
+++ b/src/en/news/blog/2010/v0-22-2-released/index.md
@@ -3,6 +3,7 @@ title: "v0.22.2 released"
 date: "2010-10-30"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.22.2 is out with a few minor bug fixes:

--- a/src/en/news/blog/2010/v0-22-released/index.md
+++ b/src/en/news/blog/2010/v0-22-released/index.md
@@ -3,6 +3,7 @@ title: "v0.22 released"
 date: "2010-10-15"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It’s a bit late, but v0.22 is here.  The original goal for this release was to have a stable clustered MDS that we can encourage users to test.  Unfortunately, we did not quite make that mark: there are still a couple significant bugs we’re working on, and I don’t want to push this release back any farther.  In retrospect, having such an infrequent release schedule to begin with (>2 months since v0.21!) makes our life a bit harder because we are tracking bug fixes in both branches, and end up with a long delay between a new feature being merged and most users testing it.  For the next release (and the immediate future), we will be aiming for more frequent releases, and will stick as close as possible to the original timeline.

--- a/src/en/news/blog/2010/v0-23-1-released/index.md
+++ b/src/en/news/blog/2010/v0-23-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.23.1 released"
 date: "2010-11-23"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This release includes some bug fixes for v0.23, although there’s nothing here that too many people have been hitting, fortunately.

--- a/src/en/news/blog/2010/v0-23-released/index.md
+++ b/src/en/news/blog/2010/v0-23-released/index.md
@@ -3,6 +3,7 @@ title: "v0.23 released"
 date: "2010-11-12"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another month, and v0.23 is out.  The main milestone here is that clustered MDS is pretty stable.  Stable enough that, if you’re interested and willing, we’d like you to try it and let us know what problems you have.  Notably, clustered recovery is _not_ yet well tested (that’s v0.24), so don’t do this unless you’re feeling adventurous.  Directory fragmentation (splitting and merging) is also working, although still off by default.  If you’d like to try that too, add ‘mds bal frag = true’ to your \[mds\] section.

--- a/src/en/news/blog/2010/v0-24-released/index.md
+++ b/src/en/news/blog/2010/v0-24-released/index.md
@@ -3,6 +3,7 @@ title: "v0.24 released"
 date: "2010-12-21"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.24, just in time for the holidays!  Big changes this time around include:

--- a/src/en/news/blog/2011/0-29-released/index.md
+++ b/src/en/news/blog/2011/0-29-released/index.md
@@ -3,6 +3,7 @@ title: "v0.29 released"
 date: "2011-06-08"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Ceph v0.29 is ready.  Notable changes since v0.28.2 include

--- a/src/en/news/blog/2011/v0-24-1-released/index.md
+++ b/src/en/news/blog/2011/v0-24-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.24.1 released"
 date: "2011-01-10"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.24.1 has been released, with a number of bug fixes from v0.24.  These include:

--- a/src/en/news/blog/2011/v0-24-2-released/index.md
+++ b/src/en/news/blog/2011/v0-24-2-released/index.md
@@ -3,6 +3,7 @@ title: "v0.24.2 released"
 date: "2011-01-25"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This is a bugfix release.  Changes since v0.24.1 include:

--- a/src/en/news/blog/2011/v0-24-3-released/index.md
+++ b/src/en/news/blog/2011/v0-24-3-released/index.md
@@ -3,6 +3,7 @@ title: "v0.24.3 released"
 date: "2011-02-11"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.24.3 with more bug fixes, including one that loses data in certain cases when OSDs restart during recovery. It’s pretty much all OSD stuff, which is where we’re focusing our testing efforts currently.

--- a/src/en/news/blog/2011/v0-25-1-released/index.md
+++ b/src/en/news/blog/2011/v0-25-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.25.1 released"
 date: "2011-03-15"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This a bugfix release.  If you’re using librados or librbd, please

--- a/src/en/news/blog/2011/v0-25-released/index.md
+++ b/src/en/news/blog/2011/v0-25-released/index.md
@@ -3,6 +3,7 @@ title: "v0.25 released"
 date: "2011-03-06"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve just tagged the v0.25 release.  Most of the work here is in the OSD

--- a/src/en/news/blog/2011/v0-26-released/index.md
+++ b/src/en/news/blog/2011/v0-26-released/index.md
@@ -3,6 +3,7 @@ title: "v0.26 released"
 date: "2011-04-05"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We tagged v0.26 a few days ago.  Changes since the last release include:

--- a/src/en/news/blog/2011/v0-27-1-released/index.md
+++ b/src/en/news/blog/2011/v0-27-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.27.1 released"
 date: "2011-05-05"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.27.1. This includes a few bugfixes for v0.27, including

--- a/src/en/news/blog/2011/v0-27-released/index.md
+++ b/src/en/news/blog/2011/v0-27-released/index.md
@@ -3,6 +3,7 @@ title: "v0.27 released"
 date: "2011-04-24"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.27 is done!  This mostly bugfixes, cleanups, and incremental

--- a/src/en/news/blog/2011/v0-28-1-released/index.md
+++ b/src/en/news/blog/2011/v0-28-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.28.1 released"
 date: "2011-05-24"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 I tagged and uploaded v0.28 a week ago but forgot to blog and email about it. That may be just as well, as there were a number of issues that got fixed last week. I’ll separate out the main items.

--- a/src/en/news/blog/2011/v0-28-2-released/index.md
+++ b/src/en/news/blog/2011/v0-28-2-released/index.md
@@ -3,6 +3,7 @@ title: "v0.28.2 released"
 date: "2011-05-29"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve tagged v0.28.2, which includes several bugs fixed over the past week.  These include:

--- a/src/en/news/blog/2011/v0-29-1-released/index.md
+++ b/src/en/news/blog/2011/v0-29-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.29.1 released"
 date: "2011-06-16"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released 0.29.1 with a few fixes. The main thing is a fix for a  

--- a/src/en/news/blog/2011/v0-30-released/index.md
+++ b/src/en/news/blog/2011/v0-30-released/index.md
@@ -3,6 +3,7 @@ title: "v0.30 released"
 date: "2011-06-28"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’re pushing out v0.30. Highlights include:

--- a/src/en/news/blog/2011/v0-31-released/index.md
+++ b/src/en/news/blog/2011/v0-31-released/index.md
@@ -3,6 +3,7 @@ title: "v0.31 released"
 date: "2011-07-09"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.31. Notable changes include:

--- a/src/en/news/blog/2011/v0-32-released/index.md
+++ b/src/en/news/blog/2011/v0-32-released/index.md
@@ -3,6 +3,7 @@ title: "v0.32 released"
 date: "2011-08-01"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve released v0.32. Notable in this release:

--- a/src/en/news/blog/2011/v0-33-released/index.md
+++ b/src/en/news/blog/2011/v0-33-released/index.md
@@ -3,6 +3,7 @@ title: "v0.33 released"
 date: "2011-08-17"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.33 is out. Notable changes this time around:

--- a/src/en/news/blog/2011/v0-34-released/index.md
+++ b/src/en/news/blog/2011/v0-34-released/index.md
@@ -3,6 +3,7 @@ title: "v0.34 released"
 date: "2011-08-27"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another 2 weeks, another release. Notable changes in v0.34:

--- a/src/en/news/blog/2011/v0-35-released/index.md
+++ b/src/en/news/blog/2011/v0-35-released/index.md
@@ -3,6 +3,7 @@ title: "v0.35 released"
 date: "2011-09-21"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 **WARNING: There is a disk format change in this release that requires a bit of extra care to upgrade safely.  Please see below.**

--- a/src/en/news/blog/2011/v0-36-released/index.md
+++ b/src/en/news/blog/2011/v0-36-released/index.md
@@ -3,6 +3,7 @@ title: "v0.36 released"
 date: "2011-10-01"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It’s been three weeks and v0.36 is ready.  The most visible change this time around is that the daemons and tools have been renamed.  Everything that used to start with ‘**c’** now starts with ‘**ceph-’**, and **libceph** is now **libcephfs**.  Nothing earth shattering, but we’re trying to clean these things up where we can and deal with the pain sooner rather than later.  (If you have any naming or tool usage pet peeves, let us know.)

--- a/src/en/news/blog/2011/v0-37-released/index.md
+++ b/src/en/news/blog/2011/v0-37-released/index.md
@@ -3,6 +3,7 @@ title: "v0.37 released"
 date: "2011-10-18"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.37 is ready.  Notable changes this time around:

--- a/src/en/news/blog/2011/v0-38-released/index.md
+++ b/src/en/news/blog/2011/v0-38-released/index.md
@@ -3,6 +3,7 @@ title: "v0.38 released"
 date: "2011-11-11"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It”s a week delayed, but v0.38 is ready.  The highlights:

--- a/src/en/news/blog/2011/v0-39-released/index.md
+++ b/src/en/news/blog/2011/v0-39-released/index.md
@@ -3,6 +3,7 @@ title: "v0.39 released"
 date: "2011-12-02"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.39 has been tagged and uploaded.  There was a lot of bug fixing going on that isn’t terribly exciting.  That aside, the highlights include:

--- a/src/en/news/blog/2012/released-v0-45/index.md
+++ b/src/en/news/blog/2012/released-v0-45/index.md
@@ -3,6 +3,7 @@ title: "Released v0.45"
 date: "2012-04-11"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.45 is ready!  Notable changes include:

--- a/src/en/news/blog/2012/v0-40-released/index.md
+++ b/src/en/news/blog/2012/v0-40-released/index.md
@@ -3,6 +3,7 @@ title: "v0.40 released"
 date: "2012-01-14"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It’s been several weeks, but v0.40 is ready.  This has mostly been a stabilization release, so there isn’t too much new here.  Some notable additions include:

--- a/src/en/news/blog/2012/v0-41-released/index.md
+++ b/src/en/news/blog/2012/v0-41-released/index.md
@@ -3,6 +3,7 @@ title: "v0.41 released"
 date: "2012-01-28"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.41 is ready!  There are a few key things in this release:

--- a/src/en/news/blog/2012/v0-42-1-released/index.md
+++ b/src/en/news/blog/2012/v0-42-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.42.2 released"
 date: "2012-02-24"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This release contains a few key fixes for v0.42:

--- a/src/en/news/blog/2012/v0-42-released/index.md
+++ b/src/en/news/blog/2012/v0-42-released/index.md
@@ -3,6 +3,7 @@ title: "v0.42 released"
 date: "2012-02-20"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.42 is ready!  This has mostly been a stabilization release, with a few critical bugs fixed.  There is also an across-the-board change in data structure encoding that is **not backwards-compatible**, but is designed to allow future changes to be (both forwards- and backwards-).

--- a/src/en/news/blog/2012/v0-43-released/index.md
+++ b/src/en/news/blog/2012/v0-43-released/index.md
@@ -3,6 +3,7 @@ title: "v0.43 released"
 date: "2012-03-02"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 V0.43 is ready, and includes:

--- a/src/en/news/blog/2012/v0-44-1-released/index.md
+++ b/src/en/news/blog/2012/v0-44-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.44.1 released"
 date: "2012-03-28"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This point release has a few important fixes:

--- a/src/en/news/blog/2012/v0-44-released/index.md
+++ b/src/en/news/blog/2012/v0-44-released/index.md
@@ -3,6 +3,7 @@ title: "v0.44 released"
 date: "2012-03-21"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 v0.44 is ready!  Changes since v0.43 include:

--- a/src/en/news/blog/2012/v0-46-released/index.md
+++ b/src/en/news/blog/2012/v0-46-released/index.md
@@ -3,6 +3,7 @@ title: "v0.46 released"
 date: "2012-04-30"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another sprint, and v0.46 is ready.  Big items in this release include:

--- a/src/en/news/blog/2012/v0-47-1-released/index.md
+++ b/src/en/news/blog/2012/v0-47-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.47.1 released"
 date: "2012-05-22"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 There was a problem with v0.47 that prevented new OSDs from detecting xattr support properly.  We’ve released v0.47.1 to resolve this issue.  If you’ve installed v0.47, and plan to create new OSDs, you should upgrade.

--- a/src/en/news/blog/2012/v0-47-2-released/index.md
+++ b/src/en/news/blog/2012/v0-47-2-released/index.md
@@ -3,6 +3,7 @@ title: "v0.47.2 released"
 date: "2012-05-23"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This point release fixes a librbd bug and a small items:

--- a/src/en/news/blog/2012/v0-47-3-released/index.md
+++ b/src/en/news/blog/2012/v0-47-3-released/index.md
@@ -3,6 +3,7 @@ title: "v0.47.3 released"
 date: "2012-06-21"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This is a bugfix release with one major fix and a few small ones:

--- a/src/en/news/blog/2012/v0-47-released/index.md
+++ b/src/en/news/blog/2012/v0-47-released/index.md
@@ -3,6 +3,7 @@ title: "v0.47 released"
 date: "2012-05-21"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It’s been another three weeks and v0.47 is ready.  The highlights include:

--- a/src/en/news/blog/2012/v0-48-1-argonaut-stable-update-released/index.md
+++ b/src/en/news/blog/2012/v0-48-1-argonaut-stable-update-released/index.md
@@ -3,6 +3,8 @@ title: "v0.48.1 ‘argonaut’ stable update released"
 date: "2012-08-14"
 author: "sage"
 tags: 
+  - "release"
+  - "argonaut"
 ---
 
 We’ve built and pushed the first update to the argonaut stable release.  This branch has a range of small fixes for stability, compatibility, and performance, but no major changes in functionality.  The stability fixes are particularly important for large clusters with many OSDs, and for network environments where intermittent network failures are more common.

--- a/src/en/news/blog/2012/v0-48-2-argonaut-stable-update-released/index.md
+++ b/src/en/news/blog/2012/v0-48-2-argonaut-stable-update-released/index.md
@@ -3,6 +3,8 @@ title: "v0.48.2 ‘argonaut’ stable update released"
 date: "2012-09-20"
 author: "sage"
 tags: 
+  - "release"
+  - "argonaut"
 ---
 
 Another update to the stable “argonaut” series has been released. This fixes a few important bugs in rbd and radosgw and includes a series of changes to upstart and deployment related scripts that will allow the upcoming ‘ceph-deploy’ tool to work with the argonaut release.

--- a/src/en/news/blog/2012/v0-48-argonaut-released/index.md
+++ b/src/en/news/blog/2012/v0-48-argonaut-released/index.md
@@ -3,6 +3,8 @@ title: "v0.48 “argonaut” released"
 date: "2012-07-03"
 author: "sage"
 tags: 
+  - "release"
+  - "argonaut"
 ---
 
 ![](images/argonaut-600.gif "argonaut")

--- a/src/en/news/blog/2012/v0-49-released/index.md
+++ b/src/en/news/blog/2012/v0-49-released/index.md
@@ -3,6 +3,7 @@ title: "v0.49 released"
 date: "2012-07-24"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This release is a bit less exciting than most because it is the first development release since argonaut, and much of our time has been spent working on stability.  Most of those fixes have been backported and slated for the next argonaut point release (v0.48.1).   I’ll include both below; see the 0.48.1 release notes (when it’s available later this week) to see what changes with argonaut.

--- a/src/en/news/blog/2012/v0-50-released/index.md
+++ b/src/en/news/blog/2012/v0-50-released/index.md
@@ -3,6 +3,7 @@ title: "v0.50 released"
 date: "2012-08-13"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 The next development release v0.50 is ready, and includes:

--- a/src/en/news/blog/2012/v0-51-released/index.md
+++ b/src/en/news/blog/2012/v0-51-released/index.md
@@ -3,6 +3,7 @@ title: "v0.51 released"
 date: "2012-08-26"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 The latest development release v0.51 is ready.  Notable changes include:

--- a/src/en/news/blog/2012/v0-52-released/index.md
+++ b/src/en/news/blog/2012/v0-52-released/index.md
@@ -3,6 +3,7 @@ title: "v0.52 released"
 date: "2012-09-26"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 After several weeks of testing v0.52 is ready!  This is a big release for RBD and radosgw users.  Highlights include:

--- a/src/en/news/blog/2012/v0-53-released/index.md
+++ b/src/en/news/blog/2012/v0-53-released/index.md
@@ -3,6 +3,7 @@ title: "v0.53 released"
 date: "2012-10-16"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another development release of Ceph is ready, v0.53.  We are getting pretty close to what will be frozen for the next stable release (bobtail), so if you would like a preview, give this one a go.  Notable changes include:

--- a/src/en/news/blog/2012/v0-54-released/index.md
+++ b/src/en/news/blog/2012/v0-54-released/index.md
@@ -3,6 +3,7 @@ title: "v0.54 released"
 date: "2012-11-14"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 The v0.54 development release is ready!  This will be the last development release before v0.55 “bobtail,” our next long-term stable release, is ready.  Notable changes this time around include:

--- a/src/en/news/blog/2012/v0-55-1-released/index.md
+++ b/src/en/news/blog/2012/v0-55-1-released/index.md
@@ -3,6 +3,7 @@ title: "v0.55.1 released"
 date: "2012-12-13"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 There were some packaging and init script issues with v0.55, so a small point release is out. It fixes a few odds and ends:

--- a/src/en/news/blog/2012/v0-55-released/index.md
+++ b/src/en/news/blog/2012/v0-55-released/index.md
@@ -3,6 +3,7 @@ title: "v0.55 released"
 date: "2012-12-04"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We had originally planned to make v0.55 a long-term stable release, but a lot of last-minute changes and fixes went into this cycle, so we are going to wait another cycle and make v0.56 bobtail.   A lot of work went into v0.55, however.  If you aren’t running argonaut (v0.48.\*), please give v0.55 a try and help us make sure it is rock solid!

--- a/src/en/news/blog/2013/v0-48-3-argonaut-update-released/index.md
+++ b/src/en/news/blog/2013/v0-48-3-argonaut-update-released/index.md
@@ -3,6 +3,8 @@ title: "v0.48.3 argonaut update released"
 date: "2013-01-09"
 author: "sage"
 tags: 
+  - "release"
+  - "argonaut"
 ---
 
 After several months, we have an important update for the argonaut v0.48.x series.  This release contains a **critical fix that can prevent data loss or corruption** in a power loss or kernel panic situation.  There are also several fixes for the OSDs and for the radosgw.  We recommend all v0.48.x users upgrade.

--- a/src/en/news/blog/2013/v0-56-1-released/index.md
+++ b/src/en/news/blog/2013/v0-56-1-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56.1 released"
 date: "2013-01-08"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 We found a few critical problems with v0.56, and fixed a few outstanding problems.  v0.56.1 is ready, and we’re pretty pleased with it!

--- a/src/en/news/blog/2013/v0-56-2-released/index.md
+++ b/src/en/news/blog/2013/v0-56-2-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56.2 released"
 date: "2013-01-30"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 The next bobtail point release is ready, and it’s looking pretty good.  This is an important update for the 0.56.x backport series that fixes a number of bugs and several performance issues.  All v0.56.x users are encouraged to upgrade.

--- a/src/en/news/blog/2013/v0-56-3-released/index.md
+++ b/src/en/news/blog/2013/v0-56-3-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56.3 released"
 date: "2013-02-14"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 We’ve fixed an important bug that a few users were hitting with unresponsive OSDs and internal heartbeat timeouts.  This, along with a range of less critical fixes, was sufficient to justify another point release.  Any production users should upgrade.

--- a/src/en/news/blog/2013/v0-56-4-released/index.md
+++ b/src/en/news/blog/2013/v0-56-4-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56.4 released"
 date: "2013-03-25"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 There have been several important fixes that we’ve backported to bobtail that users are hitting in the wild.  Most notably, there was a problem with pool names with – and \_ that OpenStack users were hitting, and memory usage by ceph-osd and other daemons due to the trimming of in-memory logs.  This and more is fixed in v0.56.4.  We recommend that all bobtail users upgrade.

--- a/src/en/news/blog/2013/v0-56-5-released/index.md
+++ b/src/en/news/blog/2013/v0-56-5-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56.5 released"
 date: "2013-05-03"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 Behold, another Bobtail update!  This one serves three main purposes: it fixes a small issue with monitor features that is important when upgrading from argonaut -> bobtail -> cuttlefish, it backports many changes to the ceph-disk helper scripts that allow bobtail clusters to be deployed with [the new ceph-deploy tool](http://ceph.com/docs/master/rados/deployment/) or [our chef cookbooks](https://github.com/ceph/ceph-cookbooks), and it fixes several important bugs in librbd.  There is also, of course, the usual collection of important bug fixes in other parts of the system.

--- a/src/en/news/blog/2013/v0-56-7-bobtail-released/index.md
+++ b/src/en/news/blog/2013/v0-56-7-bobtail-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56.7 Bobtail released"
 date: "2013-08-28"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 We have another bugfix update for bobtail. Most of these fixes have been sitting in the bobtail branch (and were run by various users) for some time now. The newest patches fix a problem with multi-delete on rgw. We recommend that production bobtail clusters upgrade, especially if they are using the radosgw.

--- a/src/en/news/blog/2013/v0-56-released/index.md
+++ b/src/en/news/blog/2013/v0-56-released/index.md
@@ -3,6 +3,8 @@ title: "v0.56 released"
 date: "2013-01-01"
 author: "sage"
 tags: 
+  - "release"
+  - "bobtail"
 ---
 
 We’re bringing in the new year with a new release, v0.56, which will form the basis of the next stable series “bobtail.”  There is little in the way of new functionality since v0.55, as we’ve been focusing primarily on stability, performance, and upgradability from the previous argonaut stable series (v0.48.x).  If you are a current argonaut user, you can either upgrade now, or watch the [Inktank blog](http://www.inktank.com/news-events/blog/) for the bobtail announcement after some additional testing has been completed.  If you are a v0.55 or v0.55.1 user, we recommend upgrading now.

--- a/src/en/news/blog/2013/v0-57-released/index.md
+++ b/src/en/news/blog/2013/v0-57-released/index.md
@@ -3,6 +3,7 @@ title: "v0.57 released"
 date: "2013-02-19"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 We’ve been spending a lot of time working on bobtail-related stabilization and bug fixes, but our next development release v0.57 is finally here!  Notable changes include:

--- a/src/en/news/blog/2013/v0-58-released/index.md
+++ b/src/en/news/blog/2013/v0-58-released/index.md
@@ -3,6 +3,7 @@ title: "v0.58 released"
 date: "2013-03-05"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 It’s been two weeks and v0.58 is baked.  Notable changes since v0.57 include:

--- a/src/en/news/blog/2013/v0-59-released/index.md
+++ b/src/en/news/blog/2013/v0-59-released/index.md
@@ -3,6 +3,7 @@ title: "v0.59 released"
 date: "2013-03-21"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another sprint and another release! This one is delayed a day or two due to power issues in our data center. The most exciting bit here is a big refactor in the monitor that has finally landed (thanks go to Joao Luis), but there is lots of other good stuff to go around:

--- a/src/en/news/blog/2013/v0-60-released/index.md
+++ b/src/en/news/blog/2013/v0-60-released/index.md
@@ -3,6 +3,7 @@ title: "v0.60 released"
 date: "2013-04-02"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another sprint and another release! This is the last development release  

--- a/src/en/news/blog/2013/v0-61-1-released/index.md
+++ b/src/en/news/blog/2013/v0-61-1-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.1 released"
 date: "2013-05-09"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 This release is a small update to Cuttlefish that fixes a problem when upgrading a bobtail cluster that had snapshots. Please use this instead of v0.61 if you are upgrading to avoid possible ceph-osd daemon crashes. There is also fix for a problem deploying monitors and generating new authentication keys.

--- a/src/en/news/blog/2013/v0-61-2-released/index.md
+++ b/src/en/news/blog/2013/v0-61-2-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.2 released"
 date: "2013-05-14"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 This release has only two changes: it disables a debug log by default that consumes disk space on the monitor, and fixes a bug with upgrading bobtail monitor stores with duplicated GV values. We urge all v0.61.1 users to upgrade to avoid filling the monitor data disks.

--- a/src/en/news/blog/2013/v0-61-3-released/index.md
+++ b/src/en/news/blog/2013/v0-61-3-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.3 released"
 date: "2013-06-06"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 This is a much-anticipated point release for the v0.61 Cuttlefish stable series.  It resolves a number of issues, primarily with monitor stability and leveldb trimming.  All v0.61.x uses are encouraged to upgrade.

--- a/src/en/news/blog/2013/v0-61-4-released/index.md
+++ b/src/en/news/blog/2013/v0-61-4-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.4 released"
 date: "2013-06-20"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 We have resolved a number of issues that v0.61.x Cuttlefish users have been hitting and have prepared another point release, v0.61.4.  This release fixes a rare data corruption during power cycle when using the XFS file system, a few monitor sync problems, several issues with ceph-disk and ceph-deploy on RHEL/CentOS, and a problem with OSD memory utilization during scrub.

--- a/src/en/news/blog/2013/v0-61-5-cuttlefish-update-released/index.md
+++ b/src/en/news/blog/2013/v0-61-5-cuttlefish-update-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.5 Cuttlefish update released"
 date: "2013-07-18"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 We’ve prepared another update for the Cuttlefish v0.61.x series. This release primarily contains monitor stability improvements, although there are also some important fixes for ceph-osd for large clusters and a few important CephFS fixes. We recommend that all v0.61.x users upgrade.

--- a/src/en/news/blog/2013/v0-61-6-cuttlefish-update-released/index.md
+++ b/src/en/news/blog/2013/v0-61-6-cuttlefish-update-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.6 Cuttlefish update released"
 date: "2013-07-24"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 There was a problem with the monitor daemons in v0.61.5 that would prevent them from restarting after some period of time.  This release fixes the bug and works around the issue to allow affected monitors to restart.  All v0.61.5 users are strongly recommended to upgrade.

--- a/src/en/news/blog/2013/v0-61-7-cuttlefish-update-released/index.md
+++ b/src/en/news/blog/2013/v0-61-7-cuttlefish-update-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.7 Cuttlefish update released"
 date: "2013-07-25"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 This release fixes another regression preventing monitors to start after undergoing certain upgrade sequences, as well as some corner cases with Paxos and unusual device names in ceph-disk/cephde-loy.

--- a/src/en/news/blog/2013/v0-61-8-cuttlefish-released/index.md
+++ b/src/en/news/blog/2013/v0-61-8-cuttlefish-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.8 Cuttlefish released"
 date: "2013-08-19"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 We’ve made another point release for Cuttlefish.  This release contains a number of fixes that are generally not individually critical, but do trip up users from time to time, are non-intrusive, and have held up under testing.

--- a/src/en/news/blog/2013/v0-61-9-cuttlefish-released/index.md
+++ b/src/en/news/blog/2013/v0-61-9-cuttlefish-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61.9 Cuttlefish released"
 date: "2013-10-17"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 This point release resolves several low to medium-impact bugs across the code base, and fixes a performance problem (CPU utilization) with radosgw. We recommend that all production cuttlefish users upgrade.

--- a/src/en/news/blog/2013/v0-61-cuttlefish-released/index.md
+++ b/src/en/news/blog/2013/v0-61-cuttlefish-released/index.md
@@ -3,6 +3,8 @@ title: "v0.61 “Cuttlefish” released"
 date: "2013-05-07"
 author: "sage"
 tags: 
+  - "release"
+  - "cuttlefish"
 ---
 
 Spring has arrived (at least for some of us), and a new stable release of Ceph is ready.  Thank you to everyone who has contributed to this release!

--- a/src/en/news/blog/2013/v0-62-released/index.md
+++ b/src/en/news/blog/2013/v0-62-released/index.md
@@ -3,6 +3,7 @@ title: "v0.62 released"
 date: "2013-05-14"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This is the first release after cuttlefish. Since most of this window was spent on stabilization, there isn’t a lot of new stuff here aside from cleanups and fixes (most of which are backported to v0.61). v0.63 is due out in 2 weeks and will have more goodness.

--- a/src/en/news/blog/2013/v0-63-released/index.md
+++ b/src/en/news/blog/2013/v0-63-released/index.md
@@ -3,6 +3,7 @@ title: "v0.63 released"
 date: "2013-05-29"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another sprint, and v0.63 is here.  This release features librbd improvements, mon fixes, osd robustness, and packaging fixes.

--- a/src/en/news/blog/2013/v0-64-released/index.md
+++ b/src/en/news/blog/2013/v0-64-released/index.md
@@ -3,6 +3,7 @@ title: "v0.64 released"
 date: "2013-06-12"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 A new development release of Ceph is out. Notable changes include:

--- a/src/en/news/blog/2013/v0-65-released/index.md
+++ b/src/en/news/blog/2013/v0-65-released/index.md
@@ -3,6 +3,7 @@ title: "v0.65 released"
 date: "2013-06-25"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Our next development release v0.65 is out, with a few big changes.  First and foremost, this release includes a complete revamp of the architecture for the command line interface in order to lay the groundwork for our ongoing REST management API work.  The ‘ceph’ command line tool is now a thin python wrapper around librados.  Note that this set of changes includes several small incompatible changes in the interface that tools or scripts utilizing the CLI should be aware of; these are detailed in [the complete release notes](http://ceph.com/docs/master/release-notes/#v0-65).

--- a/src/en/news/blog/2013/v0-66-released/index.md
+++ b/src/en/news/blog/2013/v0-66-released/index.md
@@ -3,6 +3,7 @@ title: "v0.66 released"
 date: "2013-07-09"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Our last development release before dumpling is here! The main improvements here are with monitor performance and OSD pg log rewrites to speed up peeering.

--- a/src/en/news/blog/2013/v0-67-1-dumpling-released/index.md
+++ b/src/en/news/blog/2013/v0-67-1-dumpling-released/index.md
@@ -3,6 +3,8 @@ title: "v0.67.1 Dumpling released"
 date: "2013-08-17"
 author: "sage"
 tags: 
+  - "release"
+  - "dumpling"
 ---
 
 This is a bug fix release for Dumpling that resolves a problem with the librbd python bindings (triggered by OpenStack) and a hang in librbd when caching is disabled.

--- a/src/en/news/blog/2013/v0-67-2-dumpling-released/index.md
+++ b/src/en/news/blog/2013/v0-67-2-dumpling-released/index.md
@@ -3,6 +3,8 @@ title: "v0.67.2 Dumpling released"
 date: "2013-08-23"
 author: "sage"
 tags: 
+  - "release"
+  - "dumpling"
 ---
 
 This is an imporant point release for Dumpling. Most notably, it fixes a problem when upgrading directly from v0.56.x Bobtail to v0.67.x Dumpling (without stopping at v0.61.x Cuttlefish along the way). It also fixes a problem with the CLI parsing of the CEPH\_ARGS environment variable (which causes problems with older releases of OpenStack), high CPU utilization by the ceph-osd daemons, and cleans up the radosgw shutdown sequence.

--- a/src/en/news/blog/2013/v0-67-3-dumpling-released/index.md
+++ b/src/en/news/blog/2013/v0-67-3-dumpling-released/index.md
@@ -3,6 +3,8 @@ title: "v0.67.3 Dumpling released"
 date: "2013-09-10"
 author: "sage"
 tags: 
+  - "release"
+  - "dumpling"
 ---
 
 This point release fixes a few important performance regressions with the OSD (both with CPU and disk utilization), as well as several other important but less common problems. We recommend that all production users upgrade.

--- a/src/en/news/blog/2013/v0-67-4-dumpling-released/index.md
+++ b/src/en/news/blog/2013/v0-67-4-dumpling-released/index.md
@@ -3,6 +3,8 @@ title: "v0.67.4 Dumpling released"
 date: "2013-10-04"
 author: "sage"
 tags: 
+  - "release"
+  - "dumpling"
 ---
 
 This point release fixes an important performance issue with radosgw, keystone authentication token caching, and CORS. All users (especially those of rgw) are encouraged to upgrade.

--- a/src/en/news/blog/2013/v0-67-5-dumpling-released/index.md
+++ b/src/en/news/blog/2013/v0-67-5-dumpling-released/index.md
@@ -3,6 +3,8 @@ title: "v0.67.5 Dumpling released"
 date: "2013-12-22"
 author: "sage"
 tags: 
+  - "release"
+  - "dumpling"
 ---
 
 This release includes a few critical bug fixes for the radosgw, including a fix for hanging operations on large objects. There are also several bug fixes for radosgw multi-site replications, and a few backported features. Also, notably, the ‘osd perf’ command (which dumps recent performance information about active OSDs) has been backported.

--- a/src/en/news/blog/2013/v0-67-dumpling-released/index.md
+++ b/src/en/news/blog/2013/v0-67-dumpling-released/index.md
@@ -3,6 +3,8 @@ title: "v0.67 Dumpling released"
 date: "2013-08-14"
 author: "sage"
 tags: 
+  - "release"
+  - "dumpling"
 ---
 
 Another three months have gone by, and the next stable release of Ceph is ready: Dumpling!  Thank you to everyone who has contributed to this release (42 authors in all)!

--- a/src/en/news/blog/2013/v0-68-released/index.md
+++ b/src/en/news/blog/2013/v0-68-released/index.md
@@ -3,6 +3,7 @@ title: "v0.68 released"
 date: "2013-09-04"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Our first development release after Dumpling has arrived!  It includes a lot of small cleanups and documentation improvements, as well as the first blueprint from the Emperor CDS to land (support for ZFS).  There are also new sample implementations for RADOS classes (cls\_hello) and a sample librados application (hello\_world) to help developers and users get started.

--- a/src/en/news/blog/2013/v0-69-released/index.md
+++ b/src/en/news/blog/2013/v0-69-released/index.md
@@ -3,6 +3,7 @@ title: "v0.69 released"
 date: "2013-09-18"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Our v0.69 development release of Ceph is ready!  The most notable user-facing new feature is probably improved support for CORS in the radosgw.  There has also been a lot of new work going into the tree behind the scenes on the OSD that is laying the groundwork for tiering and cache pools.  As part of this, some of the librados API semantics have been tightened up.

--- a/src/en/news/blog/2013/v0-70-released/index.md
+++ b/src/en/news/blog/2013/v0-70-released/index.md
@@ -3,6 +3,7 @@ title: "v0.70 released"
 date: "2013-10-06"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 Another development release is out.  Our timing on these has been slightly erratic.  As a result, this one has a bit less stuff than 0.69 did or 0.71 will.  The highlights are some rgw and mon fixes, and the architecture detection for enabling the optimized Intel CRC32c code is now working (which is nice: it’s about 8x faster than the generic code!).  This is one minor librados API fix; librados users should check the [release notes](http://ceph.com/docs/master/release-notes/#v0-70).

--- a/src/en/news/blog/2013/v0-71-released/index.md
+++ b/src/en/news/blog/2013/v0-71-released/index.md
@@ -3,6 +3,7 @@ title: "v0.71 released"
 date: "2013-10-18"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This development release includes a significant amount of new code and refactoring, as well as a lot of preliminary functionality that will be needed for erasure coding and tiering support. There are also several significant patch sets improving this with the MDS.

--- a/src/en/news/blog/2013/v0-72-2-emperor-released/index.md
+++ b/src/en/news/blog/2013/v0-72-2-emperor-released/index.md
@@ -4,6 +4,7 @@ date: "2013-12-22"
 author: "sage"
 tags: 
   - "release"
+  - "emperor"
 ---
 
 This is the second bugfix release for the v0.72.x Emperor series. We have fixed a hang in radosgw, and fixed (again) a problem with monitor CLI compatiblity with mixed version monitors. (In the future this will no longer be a problem.)

--- a/src/en/news/blog/2013/v0-72-emperor-released/index.md
+++ b/src/en/news/blog/2013/v0-72-emperor-released/index.md
@@ -3,6 +3,8 @@ title: "v0.72 Emperor Released"
 date: "2013-11-09"
 author: "sage"
 tags: 
+  - "release"
+  - "emperor"
 ---
 
 This is the fifth major release of Ceph, the fourth since adopting a 3-month development cycle. This release brings several new features, including multi-datacenter replication for the radosgw, improved usability, and lands a lot of incremental performance and internal refactoring work to support upcoming features in Firefly.

--- a/src/en/news/blog/2013/v0-73-released/index.md
+++ b/src/en/news/blog/2013/v0-73-released/index.md
@@ -3,6 +3,7 @@ title: "v0.73 released"
 date: "2013-12-12"
 author: "sage"
 tags: 
+  - "release"
 ---
 
 This release, the first development release after emperor, includes many bug fixes and a few additional pieces of functionality. The first batch of larger changes will be landing in the next version, v0.74.

--- a/src/en/news/blog/2014/v0-67-10-dumpling-released/index.md
+++ b/src/en/news/blog/2014/v0-67-10-dumpling-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.67.10 Dumpling released"
 date: "2014-08-12"
 author: "sage"
+tags:
+  - "release"
+  - "dumpling"
 ---
 
 This stable update release for Dumpling includes primarily fixes for RGW, including several issues with bucket listings and a potential data corruption problem when multiple multi-part uploads race. There is also some throttling capability added in the OSD for scrub that can mitigate the performance impact on production clusters.

--- a/src/en/news/blog/2014/v0-67-11-dumpling-released/index.md
+++ b/src/en/news/blog/2014/v0-67-11-dumpling-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.67.11 Dumpling released"
 date: "2014-09-25"
 author: "sage"
+tags:
+  - "release"
+  - "dumpling"
 ---
 
 This stable update for Dumpling fixes several important bugs that affect a small set of users.

--- a/src/en/news/blog/2014/v0-67-7-dumpling-released/index.md
+++ b/src/en/news/blog/2014/v0-67-7-dumpling-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.67.7 Dumpling released"
 date: "2014-02-20"
 author: "sage"
+tags:
+  - "release"
+  - "dumpling"
 ---
 
 This Dumpling point release fixes a few critical issues in v0.67.6.

--- a/src/en/news/blog/2014/v0-67-8-dumpling-released/index.md
+++ b/src/en/news/blog/2014/v0-67-8-dumpling-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.67.8 Dumpling released"
 date: "2014-05-01"
 author: "sage"
+tags:
+  - "release"
+  - "dumpling"
 ---
 
 This Dumpling point release fixes several non-critical issues since v0.67.7. The most notable bug fixes are an auth fix in librbd (observed as an occasional crash from KVM), an improvement in the network failure detection with the monitor, and several hard to hit OSD crashes or hangs.

--- a/src/en/news/blog/2014/v0-67-9-dumpling-released/index.md
+++ b/src/en/news/blog/2014/v0-67-9-dumpling-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.67.9 Dumpling released"
 date: "2014-05-21"
 author: "sage"
+tags:
+  - "release"
+  - "dumpling"
 ---
 
 This Dumpling point release fixes several minor bugs. The most prevalent in the field is one that occasionally prevents OSDs from starting on recently created clusters.

--- a/src/en/news/blog/2014/v0-74-released/index.md
+++ b/src/en/news/blog/2014/v0-74-released/index.md
@@ -2,7 +2,8 @@
 title: "v0.74 released"
 date: "2014-01-02"
 author: "sage"
-tags: 
+tags:
+  - "release"
 ---
 
 This release includes a few substantial pieces for Firefly, including a long-overdue switch to 3x replication by default and a switch to the “new” CRUSH tunables by default (supported since bobtail). There is also a fix for a long-standing radosgw bug (stalled GET) that has already been backported to emperor and dumpling.

--- a/src/en/news/blog/2014/v0-75-released/index.md
+++ b/src/en/news/blog/2014/v0-75-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.75 released"
 date: "2014-01-15"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is a big release, with lots of infrastructure going in for firefly. The big items include a prototype standalone frontend for radosgw (which does not require apache or fastcgi), tracking for read activity on the osds (to inform tiering decisions), preliminary cache pool support (no snapshots yet), and lots of bug fixes and other work across the tree to get ready for the next batch of erasure coding patches.

--- a/src/en/news/blog/2014/v0-76-released/index.md
+++ b/src/en/news/blog/2014/v0-76-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.76 released"
 date: "2014-02-04"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This release includes another batch of updates for firefly functionality. Most notably, the cache pool infrastructure now support snapshots, the OSD backfill functionality has been generalized to include multiple targets (necessary for the coming erasure pools), and there were performance improvements to the erasure code plugin on capable processors. The MDS now properly utilizes (and seamlessly migrates to) the OSD key/value interface (aka omap) for storing directory objects. There continue to be many other fixes and improvements for usability and code portability across the tree.

--- a/src/en/news/blog/2014/v0-77-released/index.md
+++ b/src/en/news/blog/2014/v0-77-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.77 released"
 date: "2014-02-20"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the final development release before the Firefly feature freeze. The main items in this release include some additional refactoring work in the OSD IO path (include some locking improvements), per-user quotas for the radosgw, a switch to civetweb from mongoose for the prototype radosgw standalone mode, and a prototype leveldb-based backend for the OSD. The C librados API also got support for atomic write operations (read side transactions will appear in v0.78).

--- a/src/en/news/blog/2014/v0-78-released/index.md
+++ b/src/en/news/blog/2014/v0-78-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.78 released"
 date: "2014-03-22"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This development release includes two key features: erasure coding and cache tiering. A huge amount of code was merged for this release and several additional weeks were spent stabilizing the code base, and it is now in a state where it is ready to be tested by a broader user base.

--- a/src/en/news/blog/2014/v0-79-released/index.md
+++ b/src/en/news/blog/2014/v0-79-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.79 released"
 date: "2014-04-07"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This release is intended to serve as a release candidate for firefly, which will hopefully be v0.80. No changes are being made to the code base at this point except those that fix bugs. Please test this release if you intend to make use of the new erasure-coded pools or cache tiers in firefly.

--- a/src/en/news/blog/2014/v0-80-1-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-1-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.1 Firefly released"
 date: "2014-05-12"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This first Firefly point release fixes a few bugs, the most visible being a problem that prevents scrub from completing in some cases.

--- a/src/en/news/blog/2014/v0-80-3-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-3-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.3 Firefly released"
 date: "2014-07-11"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 ## V0.80.3 FIREFLY

--- a/src/en/news/blog/2014/v0-80-4-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-4-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.4 Firefly released"
 date: "2014-07-15"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This Firefly point release fixes an potential data corruption problem when ceph-osd daemons run on top of XFS and service Firefly librbd clients. A recently added allocation hint that RBD utilizes triggers an XFS bug on some kernels (Linux 3.2, and likely others) that leads to data corruption and deep-scrub errors (and inconsistent PGs). This release avoids the situation by disabling the allocation hint until we can validate which kernels are affected and/or are known to be safe to use the hint on.

--- a/src/en/news/blog/2014/v0-80-5-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-5-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.5 Firefly released"
 date: "2014-07-29"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This release fixes a few important bugs in the radosgw and fixes several packaging and environment issues, including OSD log rotation, systemd environments, and daemon restarts on upgrade.

--- a/src/en/news/blog/2014/v0-80-6-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-6-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.6 Firefly released"
 date: "2014-10-02"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This is a major bugfix release for firefly, fixing a range of issues in the OSD and monitor, particularly with cache tiering. There are also important fixes in librados, with the watch/notify mechanism used by librbd, and in radosgw.

--- a/src/en/news/blog/2014/v0-80-7-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-7-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.7 Firefly released"
 date: "2014-10-16"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This release fixes a few critical issues with v0.80.6, particularly with clusters running mixed versions.

--- a/src/en/news/blog/2014/v0-80-firefly-released/index.md
+++ b/src/en/news/blog/2014/v0-80-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80 Firefly released"
 date: "2014-05-07"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 We did it!  Firefly is built and pushed out to the ceph.com repositories.

--- a/src/en/news/blog/2014/v0-81-released/index.md
+++ b/src/en/news/blog/2014/v0-81-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.81 released"
 date: "2014-06-03"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the first development release since Firefly. It includes a lot of work that we delayed merging while stabilizing things. Lots of new functionality, as well as several fixes that are baking a bit before getting backported.

--- a/src/en/news/blog/2014/v0-82-released/index.md
+++ b/src/en/news/blog/2014/v0-82-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.82 released"
 date: "2014-06-27"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the second post-firefly development release. It includes a range of bug fixes and some usability improvements. There are some MDS debugging and diagnostic tools, an improved ‘ceph df’, and some OSD backend refactoring and cleanup.

--- a/src/en/news/blog/2014/v0-83-released/index.md
+++ b/src/en/news/blog/2014/v0-83-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.83 released"
 date: "2014-07-30"
 author: "sage"
+tags:
+  - "release"
 ---
 
 Another Ceph development release! This has been a longer cycle, so there has been quite a bit of bug fixing and stabilization in this round. There is also a bunch of packaging fixes for RPM distros (RHEL/CentOS, Fedora, and SUSE) and for systemd. We’ve also added a new librados-striper library from Sebastien Ponce that provides a generic striping API for applications to code to.

--- a/src/en/news/blog/2014/v0-84-released/index.md
+++ b/src/en/news/blog/2014/v0-84-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.84 released"
 date: "2014-08-18"
 author: "sage"
+tags:
+  - "release"
 ---
 
 The next Ceph development release is here! This release contains several meaty items, including some MDS improvements for journaling, the ability to remove the CephFS file system (and name it), several mon cleanups with tiered pools, several OSD performance branches, a new “read forward” RADOS caching mode, a prototype Kinetic OSD backend, and various radosgw improvements (especially with the new standalone civetweb frontend). And there are a zillion OSD bug fixes. Things are looking pretty good for the Giant release that is coming up in the next month.

--- a/src/en/news/blog/2014/v0-85-released/index.md
+++ b/src/en/news/blog/2014/v0-85-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.85 released"
 date: "2014-09-08"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the second-to-last development release before Giant that contains new functionality. The big items to land during this cycle are the messenger refactoring from Matt Benjmain that lays some groundwork for RDMA support, a performance improvement series from SanDisk that improves performance on SSDs, lots of improvements to our new standalone civetweb-based RGW frontend, and a new ‘osd blocked-by’ mon command that allows admins to easily identify which OSDs are blocking peering progress. The other big change is that the OSDs and Monitors now distinguish between “misplaced” and “degraded” objects: the latter means there are fewer copies than we’d like, while the former simply means the are not stored in the locations where we want them to be.

--- a/src/en/news/blog/2014/v0-87-giant-released/index.md
+++ b/src/en/news/blog/2014/v0-87-giant-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.87 Giant released"
 date: "2014-10-29"
 author: "sage"
+tags:
+  - "release"
+  - "giant"
 ---
 
 This release will form the basis for the stable release Giant, v0.87.x. Highlights for Giant include:

--- a/src/en/news/blog/2014/v0-88-released/index.md
+++ b/src/en/news/blog/2014/v0-88-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.88 released"
 date: "2014-11-12"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the first development release after Giant. The two main features merged this round are the new AsyncMessenger (an alternative implementation of the network layer) from Haomai Wang at UnitedStack, and support for POSIX file locks in ceph-fuse and libcephfs from Yan, Zheng. There is also a big pile of smaller items that re merged while we were stabilizing Giant, including a range of smaller performance and bug fixes and some new tracepoints for LTTNG.

--- a/src/en/news/blog/2014/v0-90-released/index.md
+++ b/src/en/news/blog/2014/v0-90-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.90 released"
 date: "2014-12-19"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the last development release before Christmas. There are some API cleanups for librados and librbd, and lots of bug fixes across the board for the OSD, MDS, RGW, and CRUSH. The OSD also gets support for discard (potentially helpful on SSDs, although it is off by default), and there are several improvements to ceph-disk.

--- a/src/en/news/blog/2015/v0-80-10-firefly-released/index.md
+++ b/src/en/news/blog/2015/v0-80-10-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.10 Firefly released"
 date: "2015-07-21"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This is a bugfix release for Firefly.

--- a/src/en/news/blog/2015/v0-80-11-firefly-released/index.md
+++ b/src/en/news/blog/2015/v0-80-11-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.11 Firefly released"
 date: "2015-11-19"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This is a bugfix release for Firefly.  As the Firefly 0.80.x series is nearing its planned end of life in January 2016 it may also be the last.

--- a/src/en/news/blog/2015/v0-80-8-firefly-released/index.md
+++ b/src/en/news/blog/2015/v0-80-8-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.8 Firefly released"
 date: "2015-01-14"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This is a long-awaited bugfix release for firefly. It several imporant (but relatively rare) OSD peering fixes, performance issues when snapshots are trimmed, several RGW fixes, a paxos corner case fix, and some packaging updates.

--- a/src/en/news/blog/2015/v0-80-9-firefly-released/index.md
+++ b/src/en/news/blog/2015/v0-80-9-firefly-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.80.9 Firefly released"
 date: "2015-03-10"
 author: "sage"
+tags:
+  - "release"
+  - "firefly"
 ---
 
 This is a bugfix release for firefly. It fixes a performance regression in librbd, an important CRUSH misbehavior (see below), and several RGW bugs. We have also backported support for flock/fcntl locks to ceph-fuse and libcephfs.

--- a/src/en/news/blog/2015/v0-87-1-giant-released/index.md
+++ b/src/en/news/blog/2015/v0-87-1-giant-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.87.1 Giant released"
 date: "2015-02-26"
 author: "sage"
+tags:
+  - "release"
+  - "giant"
 ---
 
 This is the first (and possibly final) point release for Giant. Our focus on stability fixes will be directed towards Hammer and Firefly.

--- a/src/en/news/blog/2015/v0-87-2-giant-released/index.md
+++ b/src/en/news/blog/2015/v0-87-2-giant-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.87.2 Giant released"
 date: "2015-04-27"
 author: "sage"
+tags:
+  - "release"
+  - "giant"
 ---
 
 This is the second (and possibly final) point release for Giant.

--- a/src/en/news/blog/2015/v0-91-released/index.md
+++ b/src/en/news/blog/2015/v0-91-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.91 released"
 date: "2015-01-14"
 author: "sage"
+tags:
+  - "release"
 ---
 
 We are quickly approaching the Hammer feature freeze but have a few more dev releases to go before we get there. The headline items are subtree-based quota support in CephFS (ceph-fuse/libcephfs client support only for now), a rewrite of the watch/notify librados API used by RBD and RGW, OSDMap checksums to ensure that maps are always consistent inside the cluster, new API calls in librados and librbd for IO hinting modeled after posix\_fadvise, and improved storage of per-PG state.

--- a/src/en/news/blog/2015/v0-92-released/index.md
+++ b/src/en/news/blog/2015/v0-92-released/index.md
@@ -2,6 +2,8 @@
 title: "v0.92 released"
 date: "2015-02-03"
 author: "sage"
+tags:
+  - "release"
 ---
 
 This is the second-to-last chunk of new stuff before Hammer. Big items include additional checksums on OSD objects, proxied reads in the cache tier, image locking in RBD, optimized OSD Transaction and replication messages, and a big pile of RGW and MDS bug fixes.

--- a/src/en/news/blog/2015/v0-93-hammer-release-candidate-released/index.md
+++ b/src/en/news/blog/2015/v0-93-hammer-release-candidate-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.93 Hammer release candidate released"
 date: "2015-02-27"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This is the first release candidate for Hammer, and includes all of the features that will be present in the final release. We welcome and encourage any and all testing in non-production clusters to identify any problems with functionality, stability, or performance before the final Hammer release.

--- a/src/en/news/blog/2015/v0-94-1-hammer-released/index.md
+++ b/src/en/news/blog/2015/v0-94-1-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.1 Hammer released"
 date: "2015-04-13"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This bug fix release fixes a few critical issues with CRUSH. The most important addresses a bug in feature bit enforcement that may prevent pre-hammer clients from communicating with the cluster during an upgrade. This only manifests in some cases (for example, when the ‘rack’ type is in use in the CRUSH map, and possibly other cases), but for safety we strongly recommend that all users use 0.94.1 instead of 0.94 when upgrading.

--- a/src/en/news/blog/2015/v0-94-2-hammer-released/index.md
+++ b/src/en/news/blog/2015/v0-94-2-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.2 Hammer released"
 date: "2015-06-11"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes a few critical bugs in RGW that can prevent objects starting with underscore from behaving properly and that prevent garbage collection of deleted objects when using the Civetweb standalone mode.

--- a/src/en/news/blog/2015/v0-94-3-hammer-released/index.md
+++ b/src/en/news/blog/2015/v0-94-3-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.3 Hammer released"
 date: "2015-08-27"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes a critical (though rare) data corruption bug that could be triggered when logs are rotated via SIGHUP. It also fixes a range of other important bugs in the OSD, monitor, RGW, RBD, and CephFS.

--- a/src/en/news/blog/2015/v0-94-4-hammer-released/index.md
+++ b/src/en/news/blog/2015/v0-94-4-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.4 Hammer released"
 date: "2015-10-19"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point fixes several important bugs in Hammer, as well as fixing interoperability issues that are required before an upgrade to Infernalis. That is, all users of earlier version of Hammer or any version of Firefly will first need to upgrade to hammer v0.94.4 or later before upgrading to Infernalis (or future releases).

--- a/src/en/news/blog/2015/v0-94-5-hammer-released/index.md
+++ b/src/en/news/blog/2015/v0-94-5-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.5 Hammer released"
 date: "2015-11-06"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes a critical regression in librbd that can cause Qemu/KVM to crash when caching is enabled on images that have been cloned.

--- a/src/en/news/blog/2015/v0-94-hammer-released/index.md
+++ b/src/en/news/blog/2015/v0-94-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94 Hammer released"
 date: "2015-04-07"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This major release is expected to form the basis of the next long-term stable series. It is intended to supersede v0.80.x Firefly.

--- a/src/en/news/blog/2015/v10-0-0-released/index.md
+++ b/src/en/news/blog/2015/v10-0-0-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.0.0 released"
 date: "2015-11-23"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This is the first development release for the Jewel cycle.  We are off to a good start, with lots of performance improvements flowing into the tree.  We are targeting sometime in Q1 2016 for the final Jewel.

--- a/src/en/news/blog/2015/v9-0-0-released/index.md
+++ b/src/en/news/blog/2015/v9-0-0-released/index.md
@@ -2,6 +2,9 @@
 title: "v9.0.0 released"
 date: "2015-05-05"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 This is the first development release for the Infernalis cycle, and the first Ceph release to sport a version number from the new numbering scheme. The “9” indicates this is the 9th release cycle–I (for Infernalis) is the 9th letter. The first “0” indicates this is a development release (“1” will mean release candidate and “2” will mean stable release), and the final “0” indicates this is the first such development release.

--- a/src/en/news/blog/2015/v9-0-1-released/index.md
+++ b/src/en/news/blog/2015/v9-0-1-released/index.md
@@ -2,6 +2,9 @@
 title: "v9.0.1 released"
 date: "2015-06-11"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 This development release is delayed a bit due to tooling changes in the build environment. As a result the next one (v9.0.2) will have a bit more work than is usual.

--- a/src/en/news/blog/2015/v9-0-2-released/index.md
+++ b/src/en/news/blog/2015/v9-0-2-released/index.md
@@ -2,6 +2,9 @@
 title: "v9.0.2 released"
 date: "2015-07-16"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 This development release features more of the OSD work queue unification, randomized osd scrub times, a huge pile of librbd fixes, more MDS repair and snapshot fixes, and a significant amount of work on the tests and build infrastructure.

--- a/src/en/news/blog/2015/v9-0-3-releasedgetting-ceph-git-gitgithub-comcephceph-git-tarball-httpceph-comdownloadceph-0-80-10-tar-gz-packages-see-httpceph-comdocsmasterinstallget-packages-ceph-d/index.md
+++ b/src/en/news/blog/2015/v9-0-3-releasedgetting-ceph-git-gitgithub-comcephceph-git-tarball-httpceph-comdownloadceph-0-80-10-tar-gz-packages-see-httpceph-comdocsmasterinstallget-packages-ceph-d/index.md
@@ -2,6 +2,9 @@
 title: "v9.0.3 released"
 date: "2015-08-24"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 This is the second to last batch of development work for the Infernalis cycle. The most intrusive change is an internal (non user-visible) change to the OSD’s ObjectStore interface. Many fixes and improvements elsewhere across RGW, RBD, and another big pile of CephFS scrub/repair improvements.

--- a/src/en/news/blog/2015/v9-1-0-infernalis-release-candidate-released/index.md
+++ b/src/en/news/blog/2015/v9-1-0-infernalis-release-candidate-released/index.md
@@ -2,6 +2,9 @@
 title: "v9.1.0 Infernalis release candidate released"
 date: "2015-10-13"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 This is the first Infernalis release candidate. There have been some major changes since Hammer, and the upgrade process is non-trivial. Please read carefully.

--- a/src/en/news/blog/2015/v9-2-0-infernalis-released/index.md
+++ b/src/en/news/blog/2015/v9-2-0-infernalis-released/index.md
@@ -2,6 +2,9 @@
 title: "v9.2.0 Infernalis released"
 date: "2015-11-06"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 ![Infernalis](images/infernalis-460x148.png)This major release will be the foundation for the next stable series. There have been some major changes since v0.94.x Hammer, and the upgrade process is non-trivial. Please read these release notes carefully.

--- a/src/en/news/blog/2016/kraken-11-0-2-released/index.md
+++ b/src/en/news/blog/2016/kraken-11-0-2-released/index.md
@@ -2,6 +2,9 @@
 title: "Kraken 11.0.2 released"
 date: "2016-10-18"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "kraken"
 ---
 
 This development checkpoint release includes a lot of changes and improvements to Kraken. This is the first release introducing ceph-mgr, a new daemon which provides additional monitoring & interfaces to external monitoring/management systems. There are also many improvements to bluestore, RGW introduces sync modules, copy part for multipart uploads and metadata search via elastic search as a tech preview. We've had to skip releasing 11.0.1 due to an issue with git tags and package versions as we were transitioning away from autotools to cmake and the new build system in place.

--- a/src/en/news/blog/2016/v0-94-6-hammer-released/index.md
+++ b/src/en/news/blog/2016/v0-94-6-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.6 Hammer released"
 date: "2016-02-23"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes a range of bugs, most notably a fix for unbounded growth of the monitor’s leveldb store, and a workaround in the OSD to keep most xattrs small enough to be stored inline in XFS inodes.

--- a/src/en/news/blog/2016/v0-94-7-hammer-released/index.md
+++ b/src/en/news/blog/2016/v0-94-7-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.7 Hammer released"
 date: "2016-05-13"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes several minor bugs. It also includes a backport of an improved ‘ceph osd reweight-by-utilization’ command for handling OSDs with higher-than-average utilizations.

--- a/src/en/news/blog/2016/v0-94-8-hammer-released/index.md
+++ b/src/en/news/blog/2016/v0-94-8-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.8 Hammer released"
 date: "2016-08-26"
 author: "sage"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes several bugs.

--- a/src/en/news/blog/2016/v10-0-2-released/index.md
+++ b/src/en/news/blog/2016/v10-0-2-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.0.2 released"
 date: "2016-01-14"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This development release includes a raft of changes and improvements for Jewel. Key additions include CephFS scrub/repair improvements, an AIX and Solaris port of librados, many librbd journaling additions and fixes, extended per-pool options, and NBD driver for RBD (rbd-nbd) that allows librbd to present a kernel-level block device on Linux, multitenancy support for RGW, RGW bucket lifecycle support, RGW support for Swift static large objects (SLO), and RGW support for Swift bulk delete.

--- a/src/en/news/blog/2016/v10-0-3-released/index.md
+++ b/src/en/news/blog/2016/v10-0-3-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.0.3 released"
 date: "2016-02-10"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This is the fourth development release for Jewel. Several big pieces have been added this release, including BlueStore (a new backend for OSD to replace FileStore), many ceph-disk fixes, a new CRUSH tunable that improves mapping stability, a new librados object enumeration API, and a whole slew of OSD and RADOS optimizations.

--- a/src/en/news/blog/2016/v10-0-4-released/index.md
+++ b/src/en/news/blog/2016/v10-0-4-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.0.4 released"
 date: "2016-03-08"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This is the fourth and last development release before Jewel. The next release will be a release candidate with the final set of features. Big items include RGW static website support, librbd journal framework, fixed mon sync of config-key data, C++11 updates, and bluestore/kstore.

--- a/src/en/news/blog/2016/v10-2-0-jewel-released/index.md
+++ b/src/en/news/blog/2016/v10-2-0-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.0 Jewel released"
 date: "2016-04-21"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This major release of Ceph will be the foundation for the next long-term stable release. There have been many major changes since the Infernalis (9.2.x) and Hammer (0.94.x) releases, and the upgrade process is non-trivial. Please read these release notes carefully.

--- a/src/en/news/blog/2016/v10-2-1-jewel-released/index.md
+++ b/src/en/news/blog/2016/v10-2-1-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.1 Jewel released"
 date: "2016-05-16"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This is the first bugfix release for Jewel. It contains several annoying packaging and init system fixes and a range of important bugfixes across RBD, RGW, and CephFS.

--- a/src/en/news/blog/2016/v10-2-2-jewel-released/index.md
+++ b/src/en/news/blog/2016/v10-2-2-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.2 Jewel released"
 date: "2016-06-15"
 author: "sage"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release fixes several important bugs in RBD mirroring, RGW multi-site, CephFS, and RADOS.

--- a/src/en/news/blog/2016/v10-2-3-jewel-released/index.md
+++ b/src/en/news/blog/2016/v10-2-3-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.3 Jewel Released"
 date: "2016-09-28"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release fixes several important bugs in RBD mirroring, RGW multi-site, CephFS, and RADOS.

--- a/src/en/news/blog/2016/v10-2-4-jewel-released/index.md
+++ b/src/en/news/blog/2016/v10-2-4-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.4 jewel released"
 date: "2016-12-07"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release fixes several important bugs in RBD mirroring, RGW multi-site, CephFS, and RADOS.

--- a/src/en/news/blog/2016/v11-1-0-kraken-released/index.md
+++ b/src/en/news/blog/2016/v11-1-0-kraken-released/index.md
@@ -2,6 +2,9 @@
 title: "v11.1.0 kraken released"
 date: "2016-12-13"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "kraken"
 ---
 
 This is a release candidate for Kraken, the next stable release series.

--- a/src/en/news/blog/2016/v11-1-1-kraken-rc-released/index.md
+++ b/src/en/news/blog/2016/v11-1-1-kraken-rc-released/index.md
@@ -2,6 +2,9 @@
 title: "v11.1.1 Kraken rc released"
 date: "2016-12-27"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "kraken"
 ---
 
 This is a release candidate for kraken, the next stable release series.

--- a/src/en/news/blog/2016/v9-2-1-infernalis-released/index.md
+++ b/src/en/news/blog/2016/v9-2-1-infernalis-released/index.md
@@ -2,6 +2,9 @@
 title: "v9.2.1 Infernalis released"
 date: "2016-02-26"
 author: "sage"
+tags:
+  - "release"
+  - "infernalis"
 ---
 
 This Infernalis point release fixes several packagins and init script issues, enables the librbd objectmap feature by default, a few librbd bugs, and a range of miscellaneous bug fixes across the system.

--- a/src/en/news/blog/2017/ceph-v12-0-2-luminous-dev-released/index.md
+++ b/src/en/news/blog/2017/ceph-v12-0-2-luminous-dev-released/index.md
@@ -2,6 +2,9 @@
 title: "Ceph v12.0.2 Luminous (dev) released"
 date: "2017-04-24"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the third development checkpoint release of Luminous, the next long term stable release.

--- a/src/en/news/blog/2017/ceph-v12-0-3-luminous-dev-released/index.md
+++ b/src/en/news/blog/2017/ceph-v12-0-3-luminous-dev-released/index.md
@@ -2,6 +2,9 @@
 title: "Ceph v12.0.3 Luminous (dev) released"
 date: "2017-05-17"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the fourth development checkpoint release of Luminous, the next long term stable release. This release introduces several improvements in bluestore, monitor, rbd & rgw.

--- a/src/en/news/blog/2017/v0-94-10-hammer-released/index.md
+++ b/src/en/news/blog/2017/v0-94-10-hammer-released/index.md
@@ -2,6 +2,9 @@
 title: "v0.94.10 Hammer released"
 date: "2017-02-22"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "hammer"
 ---
 
 This Hammer point release fixes several bugs and adds two new features.

--- a/src/en/news/blog/2017/v10-2-10-jewel-released/index.md
+++ b/src/en/news/blog/2017/v10-2-10-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.10 Jewel released"
 date: "2017-10-06"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release brings a number of important bugfixes in all major components of Ceph, we recommend all Jewel 10.2.x users to upgrade.

--- a/src/en/news/blog/2017/v10-2-6-jewel-released/index.md
+++ b/src/en/news/blog/2017/v10-2-6-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.6 Jewel released"
 date: "2017-03-08"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release fixes several important bugs in RBD mirroring, RGW multi-site, CephFS, and RADOS.

--- a/src/en/news/blog/2017/v10-2-7-jewel-released/index.md
+++ b/src/en/news/blog/2017/v10-2-7-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.7 Jewel Released"
 date: "2017-04-11"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release fixes several important bugs in RBD mirroring, librbd & RGW.

--- a/src/en/news/blog/2017/v10-2-8-jewel-released/index.md
+++ b/src/en/news/blog/2017/v10-2-8-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.8 Jewel released"
 date: "2017-07-14"
 author: "ncutler"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release brought a number of important bugfixes in all major components of Ceph. However, it also introduced a regression that could cause MDS damage, and a new release, v10.2.9, was published to address this. Therefore, Jewel users should _not_ upgrade to this version - instead, we recommend upgrading directly to v10.2.9.

--- a/src/en/news/blog/2017/v10-2-9-jewel-released/index.md
+++ b/src/en/news/blog/2017/v10-2-9-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.9 Jewel released"
 date: "2017-07-14"
 author: "ncutler"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point release fixes a regression introduced in v10.2.8.

--- a/src/en/news/blog/2017/v11-2-0-kraken-released/index.md
+++ b/src/en/news/blog/2017/v11-2-0-kraken-released/index.md
@@ -2,6 +2,9 @@
 title: "We've released the kraken!"
 date: "2017-01-20"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "kraken"
 ---
 
 ![](images/kraken.jpg)

--- a/src/en/news/blog/2017/v11-2-1-kraken-released/index.md
+++ b/src/en/news/blog/2017/v11-2-1-kraken-released/index.md
@@ -2,6 +2,9 @@
 title: "v11.2.1 Kraken released"
 date: "2017-08-10"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "kraken"
 ---
 
 This is the first bugfix release for Kraken, and probably the last release of the Kraken series (Kraken will be declared “End Of Life” (EOL) when Luminous is declared stable). It contains a large number of bugfixes across all Ceph components.

--- a/src/en/news/blog/2017/v12-0-0-luminous-dev-released/index.md
+++ b/src/en/news/blog/2017/v12-0-0-luminous-dev-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.0.0 luminous (dev) released"
 date: "2017-02-08"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the first development checkpoint release of Luminous series, the next long time release. We're off to a good start to release Luminous in the spring of '17.

--- a/src/en/news/blog/2017/v12-0-1-luminous-dev-released/index.md
+++ b/src/en/news/blog/2017/v12-0-1-luminous-dev-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.0.1 Luminous (dev) released"
 date: "2017-03-29"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the second development checkpoint release of Luminous, the next long term stable release.

--- a/src/en/news/blog/2017/v12-1-0-luminous-rc-released/index.md
+++ b/src/en/news/blog/2017/v12-1-0-luminous-rc-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.1.0 Luminous RC released"
 date: "2017-06-23"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the first release candidate for Luminous, the next long term stable release.

--- a/src/en/news/blog/2017/v12-1-1-luminous-rc-released/index.md
+++ b/src/en/news/blog/2017/v12-1-1-luminous-rc-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.1.1 Luminous RC released"
 date: "2017-07-18"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the second release candidate for Luminous, the next long term stable release. Please note that this is still a Release Candidate and not the final Luminous release.

--- a/src/en/news/blog/2017/v12-1-2-luminous-rc-released/index.md
+++ b/src/en/news/blog/2017/v12-1-2-luminous-rc-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.1.2 Luminous RC released"
 date: "2017-08-02"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the third release candidate for Luminous, the next long term stable release.

--- a/src/en/news/blog/2017/v12-1-3-luminous-rc-released/index.md
+++ b/src/en/news/blog/2017/v12-1-3-luminous-rc-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.1.3 Luminous (RC) released"
 date: "2017-08-11"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the final release candidate for Luminous, the next long term stable release.

--- a/src/en/news/blog/2017/v12-1-4-luminous-rc-released/index.md
+++ b/src/en/news/blog/2017/v12-1-4-luminous-rc-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.1.4 Luminous (RC) released"
 date: "2017-08-15"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the fifth release candidate for Luminous, the next long term stable release, we've had to do this release as there was a bug in the previous RC, 12.1.3 which affected upgrades.

--- a/src/en/news/blog/2017/v12-2-0-luminous-released/index.md
+++ b/src/en/news/blog/2017/v12-2-0-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.0 Luminous Released"
 date: "2017-08-29"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 ![](images/luminous_logo-1.png)

--- a/src/en/news/blog/2017/v12-2-1-luminous-released/index.md
+++ b/src/en/news/blog/2017/v12-2-1-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.1 Luminous released"
 date: "2017-09-28"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the first bugfix release of Luminous v12.2.x long term stable release series. It contains a range of bug fixes and a few features across CephFS, RBD & RGW. We recommend all the users of 12.2.x series update.

--- a/src/en/news/blog/2017/v12-2-2-luminous-released/index.md
+++ b/src/en/news/blog/2017/v12-2-2-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.2 Luminous released"
 date: "2017-12-01"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the second bugfix release of Luminous v12.2.x long term stable release series. It contains a range of bug fixes and a few features across Bluestore, CephFS, RBD & RGW. We recommend all the users of 12.2.x series update.

--- a/src/en/news/blog/2018/12-2-7-luminous-released/index.md
+++ b/src/en/news/blog/2018/12-2-7-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "12.2.7 Luminous released"
 date: "2018-07-17"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the seventh bugfix release of Luminous v12.2.x long term stable release series. This release contains several fixes for regressions in the v12.2.6 and v12.2.5 releases. We recommend that all users upgrade to v12.2.7.

--- a/src/en/news/blog/2018/13-2-1-mimic-released/index.md
+++ b/src/en/news/blog/2018/13-2-1-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "13.2.1 Mimic released"
 date: "2018-07-27"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the first bugfix release of the Mimic v13.2.x long term stable release series. This release contains many fixes across all components of Ceph, including a few security fixes. We recommend that all users upgrade.

--- a/src/en/news/blog/2018/13-2-2-mimic-released/index.md
+++ b/src/en/news/blog/2018/13-2-2-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "13.2.2 Mimic released"
 date: "2018-09-26"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the second bugfix release of the Mimic v13.2.x long term stable release series. This release contains many fixes across all components of Ceph. We recommend that all users upgrade.

--- a/src/en/news/blog/2018/v10-2-11-jewel-released/index.md
+++ b/src/en/news/blog/2018/v10-2-11-jewel-released/index.md
@@ -2,6 +2,9 @@
 title: "v10.2.11 Jewel released"
 date: "2018-07-11"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "jewel"
 ---
 
 This point releases brings a number of important bugfixes and has a few important security fixes. This is expected to be the last Jewel release. We recommend all Jewel 10.2.x users to upgrade.

--- a/src/en/news/blog/2018/v12-2-10-luminous-released/index.md
+++ b/src/en/news/blog/2018/v12-2-10-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.10 Luminous released"
 date: "2018-11-27"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the tenth bug fix release of the Luminous v12.2.x long term stable release series. The previous release, v12.2.9, introduced the PG hard-limit patches which were found to cause an issue in certain upgrade scenarios, and this release was expedited to revert those patches. If you already successfully upgraded to v12.2.9, you should **not** upgrade to v12.2.10, but rather **wait** for a release in which [http://tracker.ceph.com/issues/36686](http://tracker.ceph.com/issues/36686) is addressed. All other users are encouraged to upgrade to this release.

--- a/src/en/news/blog/2018/v12-2-3-luminous-released/index.md
+++ b/src/en/news/blog/2018/v12-2-3-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.3 Luminous released"
 date: "2018-02-21"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the third bugfix release of Luminous v12.2.x long term stable release series. It contains a range of bug fixes and a few features across Bluestore, CephFS, RBD & RGW. We recommend all the users of 12.2.x series update.

--- a/src/en/news/blog/2018/v12-2-4-luminous-released/index.md
+++ b/src/en/news/blog/2018/v12-2-4-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.4 Luminous Released"
 date: "2018-02-28"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the fourth bugfix release of Luminous v12.2.x long term stable release series. This was primarily intended to fix a few build, ceph-volume/ceph-disk and RGW issues. We recommend all the users of 12.2.x series to update.

--- a/src/en/news/blog/2018/v12-2-5-luminous-released/index.md
+++ b/src/en/news/blog/2018/v12-2-5-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.5 Luminous released"
 date: "2018-04-24"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the fifth bugfix release of Luminous v12.2.x long term stable release series. This release contains a range of bug fixes across all compoenents of Ceph. We recommend all the users of 12.2.x series to update.

--- a/src/en/news/blog/2018/v12-2-8-released/index.md
+++ b/src/en/news/blog/2018/v12-2-8-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.8 released"
 date: "2018-09-04"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 We're glad to announce the next point release in the Luminous v12.2.X stable release series. This release contains a range of bugfixes and stability improvements across all the components of ceph. We thank everyone for contributing towards this release.

--- a/src/en/news/blog/2018/v13-1-0-mimic-rc1-released/index.md
+++ b/src/en/news/blog/2018/v13-1-0-mimic-rc1-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.1.0 Mimic RC1 released"
 date: "2018-05-11"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the first release candidate for mimic, the next long term release. While this is not the final production release yet, consider testing this on your testing and non production clusters for a preview of upcoming features and importantly report any bugs in the tracker.

--- a/src/en/news/blog/2018/v13-2-0-mimic-released/index.md
+++ b/src/en/news/blog/2018/v13-2-0-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.0 Mimic released"
 date: "2018-06-01"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the first stable release of Mimic, the next long term release series. Please read the upgrade notes from previous releases carefully before upgrading.

--- a/src/en/news/blog/2019/13-2-3-mimic-released/index.md
+++ b/src/en/news/blog/2019/13-2-3-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "13.2.3 Mimic released"
 date: "2019-01-07"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the third bugfix release of the Mimic v13.2.x long term stable release series. This release contains many fixes across all components of Ceph.

--- a/src/en/news/blog/2019/13-2-4-mimic-released/index.md
+++ b/src/en/news/blog/2019/13-2-4-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "13.2.4 Mimic released"
 date: "2019-01-07"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the fourth bugfix release of the Mimic v13.2.x long term stable release series. This release includes two security fixes atop of v13.2.3. We recommend that all mimic users upgrade. If you've already upgraded to v13.2.3, the same restrictions from v13.2.2 to v13.2.3 apply here as well.

--- a/src/en/news/blog/2019/v12-2-11-luminous-released/index.md
+++ b/src/en/news/blog/2019/v12-2-11-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.11 Luminous released"
 date: "2019-01-31"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the eleventh bug fix release of the Luminous v12.2.x long term stable release series. We recommend that all users upgrade to this release. Please note the following precautions while upgrading.

--- a/src/en/news/blog/2019/v12-2-12-luminous-released/index.md
+++ b/src/en/news/blog/2019/v12-2-12-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.12 Luminous released"
 date: "2019-04-12"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the twelfth bug fix release of the Luminous v12.2.x long term stable release series. We recommend that all users upgrade to this release.

--- a/src/en/news/blog/2019/v13-2-5-mimic-released/index.md
+++ b/src/en/news/blog/2019/v13-2-5-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.5 Mimic released"
 date: "2019-03-13"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the fifth bugfix release of the Mimic v13.2.x long term stable release series. We recommend all Mimic users upgrade.

--- a/src/en/news/blog/2019/v13-2-6-mimic-released/index.md
+++ b/src/en/news/blog/2019/v13-2-6-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.6 Mimic released"
 date: "2019-06-04"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the sixth bugfix release of the Mimic v13.2.x long term stable release series. We recommend all Mimic users upgrade.

--- a/src/en/news/blog/2019/v13-2-7-mimic-released/index.md
+++ b/src/en/news/blog/2019/v13-2-7-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.7 mimic released"
 date: "2019-11-25"
 author: "dgalloway"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the seventh bugfix release of the Mimic v13.2.x long term stable release series. We recommend all Mimic users upgrade.

--- a/src/en/news/blog/2019/v13-2-8-mimic-released/index.md
+++ b/src/en/news/blog/2019/v13-2-8-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.8 Mimic released"
 date: "2019-12-13"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the eighth release in the Ceph Mimic stable release series. Its sole purpose is to fix a regression that found its way into the previous release.

--- a/src/en/news/blog/2019/v14-2-0-nautilus-released/index.md
+++ b/src/en/news/blog/2019/v14-2-0-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.0 Nautilus released"
 date: "2019-03-19"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 We're glad to announce the first release of Nautilus v14.2.0 stable series. There are a lot of changes across components from the previous Ceph release, and we advise everyone to go through the release and upgrade notes carefully.

--- a/src/en/news/blog/2019/v14-2-1-nautilus-released/index.md
+++ b/src/en/news/blog/2019/v14-2-1-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.1 Nautilus released"
 date: "2019-04-29"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the first bug fix release of Ceph Nautilus release series. We recommend all nautilus users upgrade to this release. For upgrading from older releases of ceph, general guidelines for upgrade to nautilus must be followed [Upgrading from Mimic or Luminous](http://docs.ceph.com/master/releases/nautilus/#nautilus-old-upgrade).

--- a/src/en/news/blog/2019/v14-2-2-nautilus-released/index.md
+++ b/src/en/news/blog/2019/v14-2-2-nautilus-released/index.md
@@ -4,6 +4,7 @@ date: "2019-07-22"
 author: "ncutler"
 tags: 
   - "release"
+  - "nautilus"
 ---
 
 This is the second bug fix release of Ceph Nautilus release series. We recommend all Nautilus users upgrade to this release. For upgrading from older releases of ceph, general guidelines for upgrade to nautilus must be followed [Upgrading from Mimic or Luminous](#nautilus-old-upgrade).

--- a/src/en/news/blog/2019/v14-2-3-nautilus-released/index.md
+++ b/src/en/news/blog/2019/v14-2-3-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.3 Nautilus released"
 date: "2019-09-04"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the third bug fix release of Ceph Nautilus release series. We recommend all Nautilus users upgrade to this release. This release fixes a security issue.  For upgrading from older releases of ceph, general guidelines for upgrade to nautilus must be followed

--- a/src/en/news/blog/2019/v14-2-4-nautilus-released/index.md
+++ b/src/en/news/blog/2019/v14-2-4-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.4 nautilus released"
 date: "2019-09-17"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the fourth release in the Ceph Nautilus stable release series. Its sole purpose is to fix a regression that found its way into the previous release.

--- a/src/en/news/blog/2019/v14-2-5-nautilus-released/index.md
+++ b/src/en/news/blog/2019/v14-2-5-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.5 Nautilus released"
 date: "2019-12-09"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the fifth release of the Ceph Nautilus release series. Among the many notable changes, this release fixes a critical BlueStore bug that was introduced in 14.2.3. All Nautilus users are advised to upgrade to this release.

--- a/src/en/news/blog/2020/v12-2-13-luminous-released/index.md
+++ b/src/en/news/blog/2020/v12-2-13-luminous-released/index.md
@@ -2,6 +2,9 @@
 title: "v12.2.13 Luminous released"
 date: "2020-02-03"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "luminous"
 ---
 
 This is the 13th bug fix release of the Luminous v12.2.x long term stable release series. We recommend that all users upgrade to this release.

--- a/src/en/news/blog/2020/v13-2-10-mimic-released/index.md
+++ b/src/en/news/blog/2020/v13-2-10-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.10 Mimic released"
 date: "2020-04-23"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the tenth bugfix release of Ceph Mimic, this release fixes a RGW CVE affecting mimic, and we recommend that all mimic users upgrade.

--- a/src/en/news/blog/2020/v13-2-9-mimic-released/index.md
+++ b/src/en/news/blog/2020/v13-2-9-mimic-released/index.md
@@ -2,6 +2,9 @@
 title: "v13.2.9 Mimic released"
 date: "2020-04-16"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "mimic"
 ---
 
 This is the ninth and very likely the last stable release in the Ceph Mimic stable release series. This release fixes bugs across all components and also contains a RGW security fix. We recommend all mimic users to upgrade to this version.

--- a/src/en/news/blog/2020/v14-2-10-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-10-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.10 Nautilus released"
 date: "2020-06-26"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the tenth release in the Nautilus series. In addition to fixing a security-related bug in RGW, this release brings a number of bugfixes across all major components of Ceph. We recommend that all Nautilus users upgrade to this release.

--- a/src/en/news/blog/2020/v14-2-11-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-11-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.11 Nautilus released"
 date: "2020-08-11"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the eleventh release in the Nautilus series. This release brings a number of bugfixes across all major components of Ceph. We recommend that all Nautilus users upgrade to this release.

--- a/src/en/news/blog/2020/v14-2-12-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-12-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.12 Nautilus Released"
 date: "2020-10-20"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 12th backport release in the Nautilus series. This release brings a number of bugfixes across all major components of Ceph. We recommend that all Nautilus users upgrade to this release.

--- a/src/en/news/blog/2020/v14-2-13-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-13-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.13 Nautilus released"
 date: "2020-11-02"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 13th backport release in the Nautilus series. This release fixes a regression introduced in v14.2.12, and a few ceph-volume & RGW fixes. We recommend users to update to this release.

--- a/src/en/news/blog/2020/v14-2-14-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-14-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.14 Nautilus released"
 date: "2020-11-19"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 14th backport release in the Nautilus series. This releases fixes a security flaw affecting Messenger V2 for Octopus & Nautilus, among other fixes across components. We recommend users to update to this release.

--- a/src/en/news/blog/2020/v14-2-15-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-15-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.15 Nautilus released"
 date: "2020-11-24"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 15th backport release in the Nautilus series. This release fixes a ceph-volume regression introduced in v14.2.13 and includes few other fixes. We recommend users to update to this release.

--- a/src/en/news/blog/2020/v14-2-16-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-16-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.16 Nautilus released"
 date: "2020-12-17"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 16th backport release in the Nautilus series. This release fixes a security flaw in CephFS. We recommend users to update to this release

--- a/src/en/news/blog/2020/v14-2-6-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-6-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.6 Nautilus released"
 date: "2020-01-08"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the sixth update to the Ceph Nautilus release series. This is a hotfix release primarily fixing a regression introduced in v14.2.5, all nautilus users are advised to upgrade to this release.

--- a/src/en/news/blog/2020/v14-2-7-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-7-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.7 nautilus released"
 date: "2020-02-03"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the seventh update to the Ceph Nautilus release series. This is a hotfix release primarily fixing a couple of security issues. We recommend that all users upgrade to this release.

--- a/src/en/news/blog/2020/v14-2-8-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-8-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.8 Nautilus released"
 date: "2020-03-03"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the eighth update to the Ceph Nautilus release series. This release fixes issues across a range of subsystems. We recommend that all users upgrade to this release.

--- a/src/en/news/blog/2020/v14-2-9-nautilus-released/index.md
+++ b/src/en/news/blog/2020/v14-2-9-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.9 Nautilus released"
 date: "2020-04-14"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the ninth bugfix release of Nautilus. This release fixes a couple of security issues in RGW & Messenger V2. We recommend all users to upgrade to this release

--- a/src/en/news/blog/2020/v15-2-0-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-0-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.0 Octopus released"
 date: "2020-03-23"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the first stable release of Ceph Octopus.

--- a/src/en/news/blog/2020/v15-2-1-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-1-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.1 Octopus released"
 date: "2020-04-09"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the first bugfix release of Ceph Octopus, we recommend all Octopus users upgrade. This release fixes an upgrade issue and also fixes 2 security issues

--- a/src/en/news/blog/2020/v15-2-2-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-2-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.2 Octopus released"
 date: "2020-05-18"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the second bugfix release of Ceph Octopus stable release series, we recommend that all Octopus users upgrade. This release has a range of fixes across all components and a security fix.

--- a/src/en/news/blog/2020/v15-2-3-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-3-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.3 Octopus released"
 date: "2020-05-30"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 We're happy to announce the availability of the third Octopus stable release series. This release mainly is a workaround for a potential OSD corruption in v15.2.2. We advise users to upgrade to v15.2.3 directly. For users running v15.2.2 please execute the following::

--- a/src/en/news/blog/2020/v15-2-4-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-4-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.4 Octopus released"
 date: "2020-06-30"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the fourth release of the Ceph Octopus stable release series. In addition to a security fix in RGW, this release brings a range of fixes across all components. We recommend that all Octopus users upgrade to this release.

--- a/src/en/news/blog/2020/v15-2-5-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-5-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.5 Octopus released"
 date: "2020-09-16"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the fifth release of the Ceph Octopus stable release series. This release brings a range of fixes across all components. We recommend that all Octopus users upgrade to this release.

--- a/src/en/news/blog/2020/v15-2-6-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-6-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.6 Octopus released"
 date: "2020-11-19"
 author: "TheAnalyst"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 6th backport release in the Octopus series. This releases fixes a  

--- a/src/en/news/blog/2020/v15-2-7-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-7-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.7 Octopus released"
 date: "2020-12-01"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 7th backport release in the Octopus series. This release fixes a serious bug in RGW that has been shown to cause data loss when a read of a large RGW object (i.e., one with at least one tail segment) takes longer than one half the time specified in the configuration option `rgw_gc_obj_min_wait`. The bug causes the tail segments of that read object to be added to the RGW garbage collection queue, which will in turn cause them to be deleted after a period of time.

--- a/src/en/news/blog/2020/v15-2-8-octopus-released/index.md
+++ b/src/en/news/blog/2020/v15-2-8-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.8 Octopus released"
 date: "2020-12-17"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 8th backport release in the Octopus series. This release fixes a security flaw in CephFS and includes a number of bug fixes. We recommend users to update to this release.

--- a/src/en/news/blog/2021/v14-2-17-nautilus-released/index.md
+++ b/src/en/news/blog/2021/v14-2-17-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.17 Nautilus released"
 date: "2021-03-11"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 17th backport release in the Nautilus series. We recommend users to update to this release

--- a/src/en/news/blog/2021/v14-2-18-nautilus-released/index.md
+++ b/src/en/news/blog/2021/v14-2-18-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.18 Nautilus released"
 date: "2021-03-15"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 18th backport release in the Nautilus series. It fixes a regression introduced in 14.2.17 in which the manager module tries to use a couple python modules that do not exist in some environments. We recommend users to update to this release

--- a/src/en/news/blog/2021/v14-2-19-nautilus-released/index.md
+++ b/src/en/news/blog/2021/v14-2-19-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.19 Nautilus released"
 date: "2021-03-30"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 19th update to the Ceph Nautilus release series. This is a hotfix release to prevent daemons from binding to loopback network interfaces. All nautilus users are advised to upgrade to this release.

--- a/src/en/news/blog/2021/v14-2-20-nautilus-released/index.md
+++ b/src/en/news/blog/2021/v14-2-20-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.20 Nautilus released"
 date: "2021-04-19"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 20th bugfix release in the Nautilus stable series. It addresses a security vulnerability in the Ceph authentication framework.  

--- a/src/en/news/blog/2021/v14-2-21-nautilus-released/index.md
+++ b/src/en/news/blog/2021/v14-2-21-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.21 Nautilus released"
 date: "2021-05-14"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is a hotfix release addressing a number of security issues and regressions. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v14-2-22-nautilus-released/index.md
+++ b/src/en/news/blog/2021/v14-2-22-nautilus-released/index.md
@@ -2,6 +2,9 @@
 title: "v14.2.22 Nautilus released"
 date: "2021-06-30"
 author: "dgalloway"
+tags:
+  - "release"
+  - "nautilus"
 ---
 
 This is the 22nd and likely the last backport release in the Nautilus series. Ultimately, we recommend all users upgrade to newer Ceph releases.

--- a/src/en/news/blog/2021/v15-2-10-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-10-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.10 Octopus released"
 date: "2021-03-18"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 10th backport release in the Octopus series. We recommend users to update to this release.

--- a/src/en/news/blog/2021/v15-2-11-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-11-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.11 Octopus released"
 date: "2021-04-19"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 11th bugfix release in the Octopus stable series. It addresses a security vulnerability in the Ceph authentication framework.  

--- a/src/en/news/blog/2021/v15-2-12-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-12-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.12 Octopus released"
 date: "2021-05-14"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is a hotfix release addressing a number of security issues and regressions. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v15-2-13-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-13-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.13 Octopus released"
 date: "2021-05-26"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 13th backport release in the Octopus series. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v15-2-14-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-14-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.14 Octopus released"
 date: "2021-08-05"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 14th backport release in the Octopus series. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v15-2-15-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-15-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.15 Octopus released"
 date: "2021-10-20"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 15th backport release in the Octopus series. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v15-2-9-octopus-released/index.md
+++ b/src/en/news/blog/2021/v15-2-9-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.9 Octopus released"
 date: "2021-02-24"
 author: "dgalloway"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 9th backport release in the Octopus series. We recommend users to update to this release.

--- a/src/en/news/blog/2021/v16-2-0-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-0-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.0 Pacific released"
 date: "2021-04-01"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 We're glad to announce the first release of the [Pacific v16.2.0 stable series](https://ceph.io/get/). There have been a lot of changes across components from the previous Ceph releases, and we advise everyone to go through the [release and upgrade notes](https://docs.ceph.com/en/latest/releases/pacific/) carefully.

--- a/src/en/news/blog/2021/v16-2-1-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-1-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.1 Pacific released"
 date: "2021-04-19"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the first bugfix release in the Pacific stable series. It addresses a security vulnerability in the Ceph authentication framework.  

--- a/src/en/news/blog/2021/v16-2-2-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-2-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.2 Pacific released"
 date: "2021-05-05"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the second backport release in the Pacific stable series. We recommend all Pacific users upgrade.

--- a/src/en/news/blog/2021/v16-2-3-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-3-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.3 Pacific released"
 date: "2021-05-06"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the third backport release in the Pacific series. We recommend all Pacific users update to this release.

--- a/src/en/news/blog/2021/v16-2-4-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-4-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.4 Pacific released"
 date: "2021-05-14"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is a hotfix release addressing a number of security issues and regressions. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v16-2-5-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-5-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.5 Pacific released"
 date: "2021-07-08"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the fifth backport release in the Pacific series. We recommend all Pacific users update to this release.

--- a/src/en/news/blog/2021/v16-2-6-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-6-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.6 Pacific released"
 date: "2021-09-16"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the sixth backport release in the Pacific series. We recommend all users update to this release.

--- a/src/en/news/blog/2021/v16-2-7-pacific-released/index.md
+++ b/src/en/news/blog/2021/v16-2-7-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.7 Pacific released"
 date: "2021-12-07"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the seventh backport release in the Pacific series. We recommend all users update to this release.

--- a/src/en/news/blog/2022/v15-2-16-octopus-released/index.md
+++ b/src/en/news/blog/2022/v15-2-16-octopus-released/index.md
@@ -2,6 +2,9 @@
 title: "v15.2.16 Octopus released"
 date: "2022-03-01"
 author: "akraitma"
+tags:
+  - "release"
+  - "octopus"
 ---
 
 This is the 16th backport release in the Octopus series. We recommend all

--- a/src/en/news/blog/2022/v16-2-8-pacific-released/index.md
+++ b/src/en/news/blog/2022/v16-2-8-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.8 Pacific released"
 date: "2022-05-16"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is the eighth backport release in the Pacific series. We recommend all users update to this release.

--- a/src/en/news/blog/2022/v16-2-9-pacific-released/index.md
+++ b/src/en/news/blog/2022/v16-2-9-pacific-released/index.md
@@ -2,6 +2,9 @@
 title: "v16.2.9 Pacific released"
 date: "2022-05-18"
 author: "dgalloway"
+tags:
+  - "release"
+  - "pacific"
 ---
 
 This is a hotfix release in the Pacific series to address a bug in 16.2.8 that could cause MGRs to deadlock.

--- a/src/en/news/blog/2022/v17-2-0-quincy-released/index.md
+++ b/src/en/news/blog/2022/v17-2-0-quincy-released/index.md
@@ -2,6 +2,9 @@
 title: "v17.2.0 Quincy released"
 date: "2022-04-19"
 author: "dgalloway"
+tags:
+  - "release"
+  - "quincy"
 ---
 
 Quincy is the 17th stable release of Ceph. It is named after Squidward Quincy Tentacles from _Spongebob Squarepants_.


### PR DESCRIPTION
I like to use the tags when browsing the Ceph blog, but I noticed that the "release" only has 3 releases that have been tagged (https://ceph.io/en/news/blog/category/release/). I figured it'd be more effective to put together this PR to kick things off. I'm not sure how these are generated right now, but I assume there's a script or a template in play. Modifying that template to include these tags could keep this up to date from now on.

I updated all releases to have the "release" tag and all releases associated with a named version of Ceph with that name.