### PR TITLE
blog: Red Hat's Ceph team is moving to IBM

### DIFF
--- a/src/en/news/blog/2022/red-hats-ceph-team-is-moving-to-ibm/index.md
+++ b/src/en/news/blog/2022/red-hats-ceph-team-is-moving-to-ibm/index.md
@@ -1,0 +1,43 @@
+---
+title: "Red Hat's Ceph team is moving to IBM"
+date: "2022-10-04"
+author: "joshd"
+tags:
+---
+
+Today IBM and Red Hat announced some big news related to Ceph: [the Ceph storage team at Red Hat is moving to IBM](https://newsroom.ibm.com/2022-10-04-IBM-Redefines-Hybrid-Cloud-Application-and-Data-Storage-Adding-Red-Hat-Storage-to-IBM-Offerings). This
+is a joint IBM/Red Hat decision, and represents a large investment in
+the continued growth and health of Ceph and its community.
+
+
+This is great news for upstream Ceph! Our project’s governance model
+and operation stays the same. Ceph continues to be 100% open-source,
+and IBM will continue to contribute with an upstream-first approach.
+
+
+IBM recognizes the success of Ceph is due to its vibrant community and
+shares our vision of a broad, collaborative open source project. IBM
+will assume Red Hat’s sponsorship of the Ceph Foundation and help
+support Ceph’s upstream test lab.
+
+
+We are incredibly excited about this new milestone for Ceph, and look
+forward to this new chapter. Ceph has come a long way from Sage Weil’s
+PhD project. Ceph is used in thousands of production clusters
+totalling several exabytes of data today, and is the leading open
+source software-defined storage solution. Since 2004, the Ceph project
+has envisioned transforming the storage industry to rely on fully open
+source software, and this is a great endorsement and realization of
+this transformation.
+
+
+We are very thankful to everyone who has contributed to Ceph’s success
+over the years. Our commitment to developing robust, scalable, open
+storage platforms continues, and we look forward to the future of
+storage, with a renewed interest in large-scale bare metal
+clusters. Together, let’s keep pushing the boundaries of storage!
+
+
+Ceph Executive Council
+
+Neha Ojha, Josh Durgin, Dan van der Ster


### PR DESCRIPTION
Signed-off-by: Josh Durgin <jdurgin@redhat.com>