### PR TITLE
community/events: Cephalocon 2023 CfP extension

### DIFF
--- a/src/en/community/events/2023/cephalocon-amsterdam/index.md
+++ b/src/en/community/events/2023/cephalocon-amsterdam/index.md
@@ -26,8 +26,8 @@ href="https://events.linuxfoundation.org/cephalocon/sponsor/">Sponsor</a>
 
 **Important Dates**
 
-- **CFP Closes:** Sunday, February 12 at 11:59 pm PST
-- **CFP Notifications:** Wednesday, February 22
+- **CFP Closes:** ~~Sunday, February 12~~ Extended to **Sunday, February 19** at 11:59 pm PST
+- **CFP Notifications:** Wednesday, February 24
 - **Schedule Announcement:** Monday, February 27
 - **Presentation Slides Due:** Wednesday, April 12
 - **Event Dates:** Monday, April 17 – Tuesday, April 18 (Developer Summit

--- a/src/en/news/blog/2023/cephalocon-2023-amsterdam/index.md
+++ b/src/en/news/blog/2023/cephalocon-2023-amsterdam/index.md
@@ -26,8 +26,8 @@ available!
 
 **Important Dates**
 
-- **CFP Closes:** Sunday, February 12 at 11:59 pm PST
-- **CFP Notifications:** Wednesday, February 22
+- **CFP Closes:** ~~Sunday, February 12~~ Extended to **Sunday, February 19** at 11:59 pm PST
+- **CFP Notifications:** Wednesday, February 24
 - **Schedule Announcement:** Monday, February 27
 - **Presentation Slide Due Date:** Wednesday, April 12
 - **Event Dates:** Monday, April 17 – Tuesday, April 18 (Developer Summit Sunday, April 16)


### PR DESCRIPTION
By popular demand, extend the Cephalocon 2023 CfP deadline by one week!

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>