### PR TITLE
src/en/community/meetups.md - update Docubetter

### DIFF
--- a/src/en/community/meetups/index.html
+++ b/src/en/community/meetups/index.html
@@ -105,11 +105,11 @@ overlaySubMenu: true
     <div>
       <h3 class="h3">Ceph DocuBetter</h3>
       <p class="p">
-        DocuBetter: a fortnightly meeting where you can complain about the condition of the Ceph documentation, get information about
-        current documentation initiatives, and learn how long you have to wait for your complaints to become documentation initiatives.
+        DocuBetter: a fortnightly meeting where you could request changes to the documentation. Discontinued in 2021. For documentation
+        complaints or requests, write directly to Zac Dover at zac.dover@proton.me.
       </p>
       <ul class="lg:mb-10 xl:mb-12 ul">
-        <li><strong>When</strong>: APAC Fourth Thursday of every month at 00:00 UTC &amp; EMEA every second Wednesday at 15:00 UTC</li>
+        <li><strong>When</strong>: Discontinued in 2021.</li>
         <li><strong>Where</strong>: Blue Jeans teleconference</li>
         <li>
           <strong>Calendar</strong>:


### PR DESCRIPTION
Update the information about the Docubetter meetup, which was discontinued in 2021. Provide information about how to get in touch with me (Zac Dover), for all those who have questions or complaints or requests pertinent to Ceph documentation.