### PR TITLE
community: update slack invite link

### DIFF
--- a/src/en/community/connect/index.html
+++ b/src/en/community/connect/index.html
@@ -169,7 +169,7 @@ order: 4
     <div>
       <h2 class="h2">Slack</h2>
       <p class="mb-0 p">
-        <a class="a" href="https://join.slack.com/t/ceph-storage/shared_invite/zt-1s4wudrqa-Ak6dxRKdvLoSTKxpAvaJQg"
+        <a class="a" href="https://join.slack.com/t/ceph-storage/shared_invite/zt-2b91em8b6-NQOKhGYReEIrE28OVncnLQ"
           >Click here to join Ceph's Slack</a
         >.
       </p>


### PR DESCRIPTION
The old one was supposed to never expire, but it seems to have anyway after ~9months. Here's a new one set to 'never expire'.