### PR TITLE
releases: Fix formatting for the 17.2.8 (el8 CERN)

### DIFF
--- a/src/en/news/blog/2024/v17-2-8-quincy-released/index.md
+++ b/src/en/news/blog/2024/v17-2-8-quincy-released/index.md
@@ -25,8 +25,8 @@ from https://docs.ceph.com/en/latest/install/get-packages/#rhel, the ceph.repo f
 point to https://download.ceph.com/rpm-17.2.7/el8 instead of https://download.ceph.com/rpm-quincy/el8
 
 These CERN packages come with no warranty and have not been tested. The software in them has been
-tested by Ceph according to [platforms](https://docs.ceph.com/en/latest/start/os-recommendations/           #platforms).
-The repository for el8 builds is hosted by CERN on [Linux @ CERN](https://linuxsoft.cern.ch/repos/ceph-ext- quincy8el-stable/).
+tested by Ceph according to [platforms](https://docs.ceph.com/en/latest/start/os-recommendations/#platforms).
+The repository for el8 builds is hosted by CERN on [Linux@CERN](https://linuxsoft.cern.ch/repos/ceph-ext-quincy8el-stable/).
 The public part of the GPG key used to sign the packages is available at
 [RPM-GPG-KEY-Ceph-Community](https://linuxsoft.cern.ch/repos/RPM-GPG-KEY-Ceph-Community).
 


### PR DESCRIPTION
Fix formatting for Quincy 17.2.8 release on ceph.io blog: https://ceph.io/en/news/blog/2024/v17-2-8-quincy-released/

Two links are broken:
- Linux @ CERN
- Platforms
