### PR TITLE
events: update Ceph Days Silicon Valley 2025 CFP

### DIFF
--- a/src/en/community/events/2025/ceph-days-almaden/index.md
+++ b/src/en/community/events/2025/ceph-days-almaden/index.md
@@ -27,3 +27,5 @@ a networking reception, to foster more Ceph learning.
 - **Speakers receive confirmation of acceptance:** 2025-02-28
 - **Schedule Announcement:** 2025-03-07
 - **Event Date:** 2025-03-25
+
+<a class="button" href="https://forms.gle/mUPxtmuRK5jJEo8y8">CFP Open!</a>


### PR DESCRIPTION
The CFP is supposed to open on 2025-01-13, please do not merge this PR before this date.