### PR TITLE
Fixed Typo in Blog

### DIFF
--- a/src/en/news/blog/2025/automating-ceph-cluster-deployments_part1/index.md
+++ b/src/en/news/blog/2025/automating-ceph-cluster-deployments_part1/index.md
@@ -48,7 +48,7 @@ Ceph clusters. Let’s take a brief look at them:
 
 ### Cephadm Introduction
 
-Unlike its predecessors, `ephadm` deploys all Ceph daemons as containers using
+Unlike its predecessors, `cephadm` deploys all Ceph daemons as containers using
 Docker or Podman. This containerized approach ensures consistency across
 different environments and simplifies the management of dependencies,
 making deploying, upgrading, and scaling Ceph clusters easier.


### PR DESCRIPTION
issue: #787

There was a typo in the [blog](ceph/ceph.io/blob/9d90814837c2cad00794f68bb50333a47c3f8cdd/src/en/news/blog/2025/automating-ceph-cluster-deployments_part1/index.md?plain=1#L51) which misspelled `cephadm` as `ephadm`.

![image](https://github.com/user-attachments/assets/453766b6-7f80-46f3-8e02-a2b3a6205f20)

raised by @mgariepy