### PR TITLE
src/en/developers/index: update documentation link

### DIFF
--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -64,7 +64,7 @@ overlaySubMenu: true
               cluster, what the components of a Ceph cluster are, how to secure your Ceph cluster, and how to get involved with the Ceph
               community.
             </p>
-            <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/start/intro/"
+            <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/"
               >Get started with Ceph (documentation)</a>
           </div>
         </div>


### PR DESCRIPTION
This PR updates the front page of Ceph/Developers with a [working link](https://docs.ceph.com/) for Ceph documentation. 
The current [link](https://docs.ceph.com/en/latest/start/intro/) under "Dive into Ceph" is broken and brings back "404 Documentation page not found".