### PR TITLE
community/connect: Update Slack invite link

### DIFF
--- a/src/en/community/connect/index.html
+++ b/src/en/community/connect/index.html
@@ -169,7 +169,7 @@ order: 4
     <div>
       <h2 class="h2">Slack</h2>
       <p class="mb-0 p">
-        <a class="a" href="https://join.slack.com/t/ceph-storage/shared_invite/zt-2ni8e8uap-C2XnzSB7gk_RQZblZkKU_A"
+        <a class="a" href="https://join.slack.com/t/ceph-storage/shared_invite/zt-32hkefbs5-f6qZDZLd5U8CYj7drBTHFw"
           >Click here to join Ceph's Slack</a
         >.
       </p>


### PR DESCRIPTION
The invite link expires after 30 days. Here's a new one.