### PR TITLE
Fix issue #854: Adjust margin for better spacing

### DIFF
--- a/src/en/discover/index.html
+++ b/src/en/discover/index.html
@@ -16,7 +16,7 @@ overlaySubMenu: true
     </div>
     <div class="wrapper">
       <div class="color-white max-w-224 mx-auto relative text-center z-1">
-        <h2 class="h1 mb-0">Ceph. The future of storage.</h2>
+        <h2 class="h1 mb-10">Ceph. The future of storage.</h2>
         <a class="button" href="/assets/pdfs/report-dec2021.pdf" rel="noreferrer noopener" target="_blank">Read the latest report</a>
       </div>
     </div>


### PR DESCRIPTION
I updated the margin-bottom (mb-0 → mb-10) for the heading inside the .wrapper div to improve spacing and visual hierarchy. This change ensures better readability and alignment on the page.

![image](https://github.com/user-attachments/assets/5490bd19-5bd8-4416-9ec2-1b15be67039e)

Fixes #854