### PR TITLE
Fix issue #842: Update obsolete links in Ceph guides section

### DIFF
--- a/src/en/developers/index.html
+++ b/src/en/developers/index.html
@@ -64,8 +64,7 @@ overlaySubMenu: true
               cluster, what the components of a Ceph cluster are, how to secure your Ceph cluster, and how to get involved with the Ceph
               community.
             </p>
-            <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/"
-              >Get started with Ceph (documentation)</a>
+            <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/">Get started with Ceph (documentation)</a>
           </div>
         </div>
       </li>
@@ -222,17 +221,31 @@ overlaySubMenu: true
   <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
     <div>
       <p class="standout">
-        Just getting started, or looking for some tips on implementing solutions for specific use cases with Ceph? We've collected some curated, downloadable guides to assist you as you explore the vast configurability and flexibility Ceph has to offer.
+        Just getting started, or looking for some tips on implementing solutions for specific use cases with Ceph? We've collected some
+        curated, downloadable guides to assist you as you explore the vast configurability and flexibility Ceph has to offer.
       </p>
     </div>
     <div>
       <h3 class="h3">Ceph basics</h3>
       <ul class="ul">
         <li>
-          <a class="a" href="https://bit.ly/Top10CephCommands" target="_blank" rel="noreferrer noopener">Ten essential Ceph commands to manage your cluster</a>
+          <a
+            class="a"
+            href="https://blog.softiron.com/engineering/10-essential-ceph-commands-for-managing-any-cluster-at-any-scale/"
+            target="_blank"
+            rel="noreferrer noopener"
+            >Ten essential Ceph commands to manage your cluster</a
+          >
         </li>
         <li>
-          <a class="a" href="https://bit.ly/5CephMistakesToAvoid" target="_blank" rel="noreferrer noopener"> Top five mistakes to avoid in your Ceph storage cluster</a>
+          <a
+            class="a"
+            href="https://s3.amazonaws.com/cdn-media.softiron.com/doc/SoftIron_Avoid+these+5+Common+DIY+Ceph+Mistakes.pdf"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            Top five mistakes to avoid in your Ceph storage cluster</a
+          >
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The "Ceph guides, tips, and tricks" section at the bottom of the Ceph Developers webpage contained two outdated links. These links were either inaccessible due to invalid SSL certificates or had moved to new locations.

Updated Links:

Ten essential Ceph commands → (https://blog.softiron.com/engineering/10-essential-ceph-commands-for-managing-any-cluster-at-any-scale/)

Top five mistakes to avoid → (https://s3.amazonaws.com/cdn-media.softiron.com/doc/SoftIron_Avoid+these+5+Common+DIY+Ceph+Mistakes.pdf)

This update ensures users can access the correct resources without broken links.

Fixes #842