### PR TITLE
doc: add date to blog post

### DIFF
--- a/src/en/news/blog/2025/rgw-tiering-enhancements-part1/index.md
+++ b/src/en/news/blog/2025/rgw-tiering-enhancements-part1/index.md
@@ -11,9 +11,9 @@ tags:
 
 ##  IBM Storage Ceph Object Storage Tiering Enhancements. Part One
 
-Note that as of the time of writing, this functionality may not yet
-be in a Ceph Squid release, but will appear in Tentacle and possibly
-a future Squid release.
+Note that as of the time of writing (mid-April 2025), this functionality may
+not yet be in a Ceph Squid release, but will appear in Tentacle and possibly a
+future Squid release.
 
 ### Introduction
 

--- a/src/en/news/blog/2025/rgw-tiering-enhancements-part2/index.md
+++ b/src/en/news/blog/2025/rgw-tiering-enhancements-part2/index.md
@@ -11,9 +11,9 @@ tags:
 
 ## Introducing Policy-Based Data Retrieval for Ceph
 
-Note that as of the time of writing, this functionality may not yet
-be in a Ceph Squid release, but will appear in Tentacle and possibly
-a future Squid release.
+Note that as of the time of writing (mid-April 2025), this functionality may
+not yet be in a Ceph Squid release, but will appear in Tentacle and possibly a
+future Squid release.
 
 ## Introduction and Feature Overview
 


### PR DESCRIPTION
Add information to Anthony D'Atri's recent blog post about IBM Storage Ceph Object Storage Tiering Enhancements about when the blog post was written, in order to future-proof the blog post.