### PR TITLE
Update contact email on 'Join the Ceph Foundation' page to support@cephfoundation.org

### DIFF
--- a/src/en/foundation/join/index.md
+++ b/src/en/foundation/join/index.md
@@ -10,6 +10,6 @@ order: 5
 
 The Ceph Foundation welcomes organizations engaged in the work of the Ceph community who wish to get involved and support.
 
-For more information, contact <membership@linuxfoundation.org>.
+For more information, contact <support@cephfoundation.org>.
 
 If your organization is ready to join, see our [membership enrollment form](https://enrollment.lfx.linuxfoundation.org/?project=cephfoundation).


### PR DESCRIPTION
This PR updates the contact email address on the [Join the Ceph Foundation](https://ceph.io/en/foundation/join/) page.​

Previous email: membership@linuxfoundation.org

Updated to: support@cephfoundation.org​

This change aligns with the current communication channels of the Ceph Foundation.

Fixes: [ceph/ceph.io#867](https://github.com/ceph/ceph.io/issues/867)
![image](https://github.com/user-attachments/assets/69faa393-3b59-41e8-8996-7b6be492b3ba)
