### PR TITLE
Fix RST syntax and typo in 17.2.9 Release notes

### DIFF
--- a/src/en/news/blog/2025/v17-2-9-quincy-released/index.md
+++ b/src/en/news/blog/2025/v17-2-9-quincy-released/index.md
@@ -30,7 +30,7 @@ still reference an older version.
 Notable Changes
 ---------------
 
-This release fixes a critical BlueStore regression in versions 17.2.8 (#63122). Users running this releas are recommended to upgrade at the earliest convenience.
+This release fixes a critical BlueStore regression in versions 17.2.8 (#63122). Users running this release are recommended to upgrade at the earliest convenience.
 
 Changelog
 ---------

--- a/src/en/news/blog/2025/v17-2-9-quincy-released/index.md
+++ b/src/en/news/blog/2025/v17-2-9-quincy-released/index.md
@@ -19,10 +19,10 @@ from https://docs.ceph.com/en/latest/install/get-packages/#rhel, the ceph.repo f
 point to https://download.ceph.com/rpm-17.2.7/el8 instead of https://download.ceph.com/rpm-quincy/el8
 
 These CERN packages come with no warranty and have not been tested. The software in them has been
-tested by Ceph according to `platforms <https://docs.ceph.com/en/latest/start/os-recommendations/#platforms>`_ .
-The repository for el8 builds is hosted by CERN on `Linux@CERN <https://linuxsoft.cern.ch/repos/ceph-ext-quincy8el-stable/>`_ .
+tested by Ceph according to [platforms](https://docs.ceph.com/en/latest/start/os-recommendations/#platforms).
+The repository for el8 builds is hosted by CERN on [Linux@CERN](https://linuxsoft.cern.ch/repos/ceph-ext-quincy8el-stable/).
 The public part of the GPG key used to sign the
-packages is available at `RPM-GPG-KEY-Ceph-Community <https://linuxsoft.cern.ch/repos/RPM-GPG-KEY-Ceph-Community>`_ .
+packages is available at [RPM-GPG-KEY-Ceph-Community](https://linuxsoft.cern.ch/repos/RPM-GPG-KEY-Ceph-Community).
 
 Also note that Ceph now builds against OpenSSL 3.5.0, which may affect EL package users who are on distros that
 still reference an older version.


### PR DESCRIPTION
Change three links from RST syntax to MD syntax.

Also fix 1 typo `releas` -> `release`.