### PR TITLE
blog: remove 'Tech Preview' from rgw account blog post

### DIFF
--- a/src/en/news/blog/2025/enhancing-ceph-multitenancy-with-iam-accounts/index.md
+++ b/src/en/news/blog/2025/enhancing-ceph-multitenancy-with-iam-accounts/index.md
@@ -14,7 +14,7 @@ tags:
 ### Introduction
 Efficient multitenant environment management is critical in large-scale object
 storage systems. In the Ceph Squid release, we’ve introduced a transformative
-feature as a Tech Preview: Identity and Access Management (IAM) accounts.
+feature: Identity and Access Management (IAM) accounts.
 
 This enhancement brings self-service resource management to Ceph Object Storage
 and significantly reduces administrative overhead for Ceph administrators by


### PR DESCRIPTION
the iam account feature is supported in the squid release. the 'tech preview' language is a downstream thing