### PR TITLE
Show upcoming events in the correct order

### DIFF
--- a/src/_11ty/filters/getItemsInFuture.js
+++ b/src/_11ty/filters/getItemsInFuture.js
@@ -11,8 +11,15 @@
 module.exports = (collection = []) => {
   const buildDate = new Date().setHours(0, 0, 0, 0);
 
-  return collection.filter(item => {
+  const filtered = collection.filter(item => {
     const formattedDate = new Date(item.data.date).setHours(0, 0, 0, 0);
+
     return formattedDate >= buildDate;
   });
+
+  const sorted = filtered.sort(
+    (a, b) => new Date(a.data.date) - new Date(b.data.date)
+  );
+
+  return sorted;
 };

--- a/src/_includes/layouts/listing-events.njk
+++ b/src/_includes/layouts/listing-events.njk
@@ -19,7 +19,7 @@
 
 {% set eventLocaleTag = locale + '-event' %}
 {% set eventFilters = collections[eventLocaleTag] | getCollectionTags([eventLocaleTag]) %}
-{% set eventsFuture = collections[eventLocaleTag] | getItemsInFuture | reverse %}
+{% set eventsFuture = collections[eventLocaleTag] | getItemsInFuture %}
 {% set eventsPast = pagination.items %}
 
 <section class="section">

--- a/src/en/community/index.html
+++ b/src/en/community/index.html
@@ -5,7 +5,7 @@ order: 4
 overlaySubMenu: true
 ---
 
-{% set eventLocaleTag = locale + '-event' %} {% set eventsFuture = collections[eventLocaleTag] | getItemsInFuture | reverse | getItems(4) %}
+{% set eventLocaleTag = locale + '-event' %} {% set eventsFuture = collections[eventLocaleTag] | getItemsInFuture | getItems(4) %}
 
 <h1 class="h1 visually-hidden">{{ title }}</h1>
 


### PR DESCRIPTION
Currently future events show the next event at the end. This fixes the order so that upcoming events are in the expected order.

- removed unnecessary calls to `reverse`
- keep list of future events sorted at source

<img width="1767" height="1003" alt="image" src="https://github.com/user-attachments/assets/f38ceb62-dd8e-4c1f-ad0e-31e3b6441369" />

upcoming events shows the "next event" first. Past events shows the "most recent one" first