### PR TITLE
fix(search): restore working fetch and escape query param against XSS

### DIFF
--- a/src/js/search-output.js
+++ b/src/js/search-output.js
@@ -17,6 +17,15 @@ const SearchOutput = {
     const urlParams = new URLSearchParams(queryString);
     const query = urlParams.get('q');
 
+    function escapeHtml(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     async function initSearchIndex() {
       if (!urlParams.has('q')) return;
 
@@ -24,13 +33,7 @@ const SearchOutput = {
         searchInput.value = query;
 
         const [searchIndex, searchOutput] = await Promise.all(
-          searchDataUrls.map(url =>
-            fetch(url, {
-              method: 'GET',
-              credentials: 'include',
-              mode: 'no-cors',
-            }).then(res => res.json())
-          )
+          searchDataUrls.map(url => fetch(url).then(res => res.json()))
         );
         const lunrIndex = lunr.Index.load(searchIndex);
 
@@ -68,10 +71,12 @@ const SearchOutput = {
 
       if (!searchresultsContainer) return;
 
+      const safeQuery = escapeHtml(query);
+
       if (!results.length) {
-        searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${noResultsString} “${query}”</p>`;
+        searchResultsHtml = `<p class=”h3 mb-8 xl:mb-10”>${noResultsString} “${safeQuery}”</p>`;
       } else {
-        searchResultsHtml = `<p class="h3 mb-8 xl:mb-10">${searchedForString} “${query}”</p>
+        searchResultsHtml = `<p class=”h3 mb-8 xl:mb-10”>${searchedForString} “${safeQuery}”</p>
       <ul class="grid md:grid--cols-2 lg:grid--cols-3 xl:grid--cols-4 list-none m-0 p-0">${results
         .map(({ author, content, date, image, title, url }) => {
           const restucturedData = {


### PR DESCRIPTION
## What this fixes

Two bugs in `src/js/search-output.js` that together have left blog search broken since June 2021.

### Bug 1 — `mode: 'no-cors'` makes search permanently non-functional

Commit 4b9c4e38 added `mode: 'no-cors'` to the fetch calls while debugging a CORS issue. The Fetch spec defines `no-cors` as returning an **opaque response** — the body is inaccessible and calling `.json()` on it always throws. The `catch` block intercepts this and shows the "couldn't complete your search" error on every single query.

The search-index and search-output files are same-origin static assets. They need no special fetch mode. This reverts to the original plain `fetch(url)` call from before that commit.

### Bug 2 — Reflected XSS via unescaped `q` URL parameter

The raw `query` value from `urlParams.get('q')` was interpolated directly into `searchResultsHtml` and then written via `innerHTML`. A crafted URL such as:

```
/en/news/blog/search/?q=<img src=x onerror=alert(document.cookie)>
```

would execute arbitrary JavaScript in the visitor's browser.

This was latent while Bug 1 was present (fetch always failed, `renderResults` was never reached). Fixing Bug 1 without this patch would immediately expose the XSS — so both are shipped together.

The fix adds a small `escapeHtml` helper and applies it to `query` before any HTML interpolation.

## What changed

- Removed `method: 'GET'`, `credentials: 'include'`, `mode: 'no-cors'` from the fetch options
- Added `escapeHtml()` function scoped inside `init()`
- Applied `escapeHtml(query)` → `safeQuery` in both the no-results and results-found branches

## What was considered and rejected

- Using `textContent` for just the query display node: would require splitting the template into separate DOM operations, larger diff than needed
- Sanitizing with a library (DOMPurify): heavyweight for a single string that only needs entity-escaping