### PR TITLE
Individual links to profiles in ambassadors page

### DIFF
--- a/src/css/base.typography.css
+++ b/src/css/base.typography.css
@@ -162,6 +162,23 @@
   transition: color var(--animation-duration) var(--animation-easing);
 }
 
+.heading-link,
+.heading-link:visited {
+  color: var(--color-red-500);
+  text-decoration: none;
+  transition: color var(--animation-duration) var(--animation-easing);
+}
+
+.heading-link:hover {
+  color: var(--color-red-500);
+  text-decoration: underline;
+}
+
+.heading-link:active {
+  color: var(--color-red-600);
+  text-decoration: underline;
+}
+
 .a:hover,
 .richtext a:hover {
   color: var(--color-red-500);

--- a/src/en/community/ambassadors/index.html
+++ b/src/en/community/ambassadors/index.html
@@ -56,7 +56,7 @@ order: 6
   <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
     <img alt="Gaurav Sitlani" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-gaurav-sitlani.jpg" />
     <div>
-      <h3 class="h3" id="Gaurav Sitlani">Gaurav Sitlani</h3>
+      <h3 class="h3" id="gaurav-sitlani"><a class="heading-link" href="#gaurav-sitlani">Gaurav Sitlani</a></h3>
       <span class="block p">Region: India</span>
       <p class="mb-0 p">
         Gaurav Sitlani, originally from Jaipur, also known as the "Pink City of India". Joined Red Hat as an Intern where he started working
@@ -80,7 +80,7 @@ order: 6
             src="/assets/bitmaps/ambassador-danny-abukalam.jpg"
           />
           <div>
-            <h3 class="h3" id="danny-abukalam">Danny Abukalam</h3>
+            <h3 class="h3" id="danny-abukalam"><a class="heading-link" href="#danny-abukalam">Danny Abukalam</a></h3>
             <span class="block p">Region: United Kingdom</span>
             <p class="mb-0 p">
               Danny Abukalam is a senior software engineer in Bloomberg's Technology Infrastructure group, working on the Storage
@@ -96,7 +96,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Aji Arya" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-arya-aji.png" />
           <div>
-            <h3 class="h3" id="arya-aji">Aji Arya</h3>
+            <h3 class="h3" id="aji-arya"><a class="heading-link" href="#aji-arya">Aji Arya</a></h3>
             <span class="block p">Region: Indonesia</span>
             <p class="mb-0 p">
               Aji Arya, hailing from the enchanting land of Borneo, Indonesia, is a dedicated cloud architect based in Indonesia.
@@ -117,7 +117,7 @@ order: 6
             src="/assets/bitmaps/ambassador-anthony-datri.jpg"
           />
           <div>
-            <h3 class="h3" id="anthony">Anthony D'Atri</h3>
+            <h3 class="h3" id="anthony-datri"><a class="heading-link" href="#anthony-datri">Anthony D'Atri</a></h3>
             <span class="block p">Region: Eastern North America</span>
             <p class="mb-0 p">
               Anthony D'Atri's career in system administration, ops, and architecture has spanned laptops to vector supercomputers. He
@@ -134,7 +134,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Cheolho Kang" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-cheolho.jpg" />
           <div>
-            <h3 class="h3" id="Cheolho">Cheolho Kang</h3>
+            <h3 class="h3" id="cheolho-kang"><a class="heading-link" href="#cheolho-kang">Cheolho Kang</a></h3>
             <span class="block p">Region: South Korea</span>
             <p class="mb-0 p">
               Cheolho Kang is a software engineer at Samsung Electronics, working on the Storage Software Team to develop Ceph. His work
@@ -153,7 +153,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Deepika Upadhyay" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-deepika.jpg" />
           <div>
-            <h3 class="h3" id="deepika">Deepika Upadhyay</h3>
+            <h3 class="h3" id="deepika-upadhyay"><a class="heading-link" href="#deepika-upadhyay">Deepika Upadhyay</a></h3>
             <span class="block p">Region: India</span>
             <p class="mb-0 p">
               Deepika is a Senior Ceph Engineer at CLYSO and is currently focused on Rook and Ceph, with experience in RADOS, RBD, and
@@ -169,7 +169,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Yite Gu" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-yite.jpg" />
           <div>
-            <h3 class="h3" id="yite-gu">Yite Gu</h3>
+            <h3 class="h3" id="yite-gu"><a class="heading-link" href="#yite-gu">Yite Gu</a></h3>
             <span class="block p">Region: China</span>
             <p class="mb-0 p">
               Yite Gu runs the Ceph project at ByteDance, as well as the integration project Rook and Ceph-CSI between Ceph and Kubernetes
@@ -186,7 +186,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Hang Geng" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-hang-geng.jpg" />
           <div>
-            <h3 class="h3" id="hang-geng">Hang Geng</h3>
+            <h3 class="h3" id="hang-geng"><a class="heading-link" href="#hang-geng">Hang Geng</a></h3>
             <span class="block p">Region: China</span>
             <p class="mb-0 p">
               Hang Geng is the community manager of CESI (China Electronics Standards Institute) and the most valuable expert of Tencent
@@ -208,7 +208,7 @@ order: 6
             src="/assets/bitmaps/ambassador-joachim-kraftmayer.jpg"
           />
           <div>
-            <h3 class="h3" id="joachim-kraftmayer">Joachim Kraftmayer</h3>
+            <h3 class="h3" id="joachim-kraftmayer"><a class="heading-link" href="#joachim-kraftmayer">Joachim Kraftmayer</a></h3>
             <span class="block p">Region: DACH</span>
             <p class="mb-0 p">
               Joachim Kraftmayer is the founder and CEO of CLYSO Inc. based out of Munich Germany with over 30 years of IT, Computer Science
@@ -230,7 +230,7 @@ order: 6
             src="/assets/bitmaps/ambassador-michiel-manten.jpg"
           />
           <div>
-            <h3 class="h3" id="Michiel Manten">Michiel Manten</h3>
+            <h3 class="h3" id="michiel-manten"><a class="heading-link" href="#michiel-manten">Michiel Manten</a></h3>
             <span class="block p">Region: Benelux (Belgium, Netherlands and Luxemburg)</span>
             <p class="mb-0 p">
               With over 25 years of IT experience, Michiel Manten has been working with Fairbanks and 42on since 2012, supporting open
@@ -253,7 +253,7 @@ order: 6
             src="/assets/bitmaps/ambassador-frederic-nass.jpg"
           />
           <div>
-            <h3 class="h3" id="Frédéric Nass">Frédéric Nass</h3>
+            <h3 class="h3" id="frederic-nass"><a class="heading-link" href="#frederic-nass">Frédéric Nass</a></h3>
             <span class="block p">Region: France</span>
             <p class="mb-0 p">
               Frédéric is a Senior Ceph Engineer at CLYSO, bringing over 20 years of experience in opensource IT infrastructure. Originally
@@ -276,7 +276,7 @@ order: 6
             src="/assets/bitmaps/ambassador-sina-moghaddas.jpg"
           />
           <div>
-            <h3 class="h3" id="ray-sun">Sina Moghaddas</h3>
+            <h3 class="h3" id="sina-moghaddas"><a class="heading-link" href="#sina-moghaddas">Sina Moghaddas</a></h3>
             <span class="block p">Region: Amsterdam</span>
             <p class="mb-0 p">
               With over a decade of experience in infrastructure design and management, Sina is a seasoned professional specializing in
@@ -294,7 +294,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Alvaro Soto" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-alvaro-soto.jpg" />
           <div>
-            <h3 class="h3" id="alvaro-soto">Alvaro Soto</h3>
+            <h3 class="h3" id="alvaro-soto"><a class="heading-link" href="#alvaro-soto">Alvaro Soto</a></h3>
             <span class="block p">Region: Mexico</span>
             <p class="mb-0 p">
               I was born in a little town in Chile called Linares. I moved to Mexico at 19 years old to <strike>start</strike> continue my
@@ -316,7 +316,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Rachana Patel" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-rachana.jpg" />
           <div>
-            <h3 class="h3" id="Rachana">Rachana Patel</h3>
+            <h3 class="h3" id="rachana-patel"><a class="heading-link" href="#rachana-patel">Rachana Patel</a></h3>
             <span class="block p">Region: Western North America</span>
             <p class="mb-0 p">
               I am an open-source enthusiast with a Bachelor’s degree in Computer Engineering and over a decade of experience in
@@ -333,7 +333,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Ray Sun" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-ray-sun.png" />
           <div>
-            <h3 class="h3" id="ray-sun">Ray Sun</h3>
+            <h3 class="h3" id="ray-sun"><a class="heading-link" href="#ray-sun">Ray Sun</a></h3>
             <span class="block p">Region: China</span>
             <p class="mb-0 p">
               Ray is the CTO of OnePro Cloud, and experienced with a demonstrated history of working in the cloud computing industry
@@ -354,7 +354,7 @@ order: 6
             src="/assets/bitmaps/ambassador-humble-devassy.jpg"
           />
           <div>
-            <h3 class="h3" id="humble-devassy">Humble Devassy</h3>
+            <h3 class="h3" id="humble-devassy"><a class="heading-link" href="#humble-devassy">Humble Devassy</a></h3>
             <span class="block p">Region: India</span>
             <p class="mb-0 p">
               Humble Devassy Chirammal is a Software Architect in the Storage Engineering team at Red Hat. He has more than 17 years of IT
@@ -374,7 +374,7 @@ order: 6
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
           <img alt="Wendy White" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-wendy-white.jpg" />
           <div>
-            <h3 class="h3" id="ray-sun">Wendy White</h3>
+            <h3 class="h3" id="wendy-white"><a class="heading-link" href="#wendy-white">Wendy White</a></h3>
             <span class="block p">Region: Australia</span>
             <p class="mb-0 p">
               Wendy White began her career as a front-end web developer and multimedia project lead for Scitech, a cutting-edge interactive
@@ -396,7 +396,7 @@ order: 6
             src="/assets/bitmaps/ambassador-thomas-bennett.jpg"
           />
           <div>
-            <h3 class="h3" id="ray-sun">Thomas Bennett</h3>
+            <h3 class="h3" id="thomas-bennett"><a class="heading-link" href="#thomas-bennett">Thomas Bennett</a></h3>
             <span class="block p">Region: South Africa</span>
             <p class="mb-0 p">
               Based in Cape Town, South Africa, Tom cofounded Tsolo.io, a company focused on Ceph-driven storage solutions. With more than
@@ -421,7 +421,7 @@ order: 6
             src="/assets/bitmaps/ambassador-ansgar-jazdzewski.png"
           />
           <div>
-            <h3 class="h3" id="ray-sun">Ansgar Jazdzewski</h3>
+            <h3 class="h3" id="ansgar-jazdzewski"><a class="heading-link" href="#ansgar-jazdzewski">Ansgar Jazdzewski</a></h3>
             <span class="block p">Region: Germany</span>
             <p class="mb-0 p">
               Ansgar is a Systems and Storage Engineer at Hetzner Cloud, where he works on object storage built on Ceph's RADOS Gateway

--- a/src/en/community/ambassadors/index.html
+++ b/src/en/community/ambassadors/index.html
@@ -10,11 +10,10 @@ order: 6
     <h2 class="h1">Ceph Ambassadors</h2>
 
     <p class="p">
-      The Ceph Ambassadors are community managers who support Ceph communities within their region with the responsibilities listed 
-      below. Get to know the team and contact your supporting ambassador by reaching out to us through the Ceph community.
-      If you are not a part of the Ceph Community, please <a class="a" href="https://ceph.io/en/community/connect/">connect with us</a>.
-
-      You can read the note from the latest Ceph Ambassador meeting <a class="a" href="https://pad.ceph.com/p/ceph-ambassadors-meeting">here</a>.
+      The Ceph Ambassadors are community managers who support Ceph communities within their region with the responsibilities listed below.
+      Get to know the team and contact your supporting ambassador by reaching out to us through the Ceph community. If you are not a part of
+      the Ceph Community, please <a class="a" href="https://ceph.io/en/community/connect/">connect with us</a>. You can read the note from
+      the latest Ceph Ambassador meeting <a class="a" href="https://pad.ceph.com/p/ceph-ambassadors-meeting">here</a>.
 
       <span class="block p">What we can help with:</span>
     </p>
@@ -31,14 +30,16 @@ order: 6
         <a class="a" href="https://tracker.ceph.com/projects/ceph/wiki/Code_Walkthroughs">Code Walkthroughs</a>.
       </li>
       <li>Promote Ceph on social media channels.</li>
-      <li> Build the community in their regions 
+      <li>
+        Build the community in their regions
         <ul>
           <li>Help in getting users & organizations connected to the Ceph Foundation & community</li>
           <li>Promote Ceph User survey & collect feedback from the community</li>
-          <li>Regional University outreach program:
+          <li>
+            Regional University outreach program:
             <ul>
               <li>Connect with the local universities, research institutions & experts</li>
-              <li>Inspire student contributors, help in getting them onboarded to the Ceph community & encourage skill development </li>
+              <li>Inspire student contributors, help in getting them onboarded to the Ceph community & encourage skill development</li>
               <li>Help with GSOC project & research ideas</li>
             </ul>
           </li>
@@ -53,20 +54,15 @@ order: 6
 
 <div class="pt-0 section">
   <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-    <img
-      alt="Gaurav Sitlani"
-      class="rounded-2 to-md:max-w-56 w-full"
-      loading="lazy"
-      src="/assets/bitmaps/ambassador-gaurav-sitlani.jpg"
-    />
+    <img alt="Gaurav Sitlani" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-gaurav-sitlani.jpg" />
     <div>
       <h3 class="h3" id="Gaurav Sitlani">Gaurav Sitlani</h3>
       <span class="block p">Region: India</span>
       <p class="mb-0 p">
-        Gaurav Sitlani, originally from Jaipur, also known as the "Pink City of India". Joined Red Hat as an Intern where he started
-        working on Ceph in 2018 supporting Enterprise customers. He graduated from University of Pune with a Bachelor's degree in
-        Computer Engineering in 2018. Been working with Ceph for over 5 years, currently he's working in IBM.
-        Leading the Ceph Community Ambassadors program. 
+        Gaurav Sitlani, originally from Jaipur, also known as the "Pink City of India". Joined Red Hat as an Intern where he started working
+        on Ceph in 2018 supporting Enterprise customers. He graduated from University of Pune with a Bachelor's degree in Computer
+        Engineering in 2018. Been working with Ceph for over 5 years, currently he's working in IBM. Leading the Ceph Community Ambassadors
+        program.
       </p>
     </div>
   </div>
@@ -98,22 +94,15 @@ order: 6
 
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img
-            alt="Aji Arya"
-            class="rounded-2 to-md:max-w-56 w-full"
-            loading="lazy"
-            src="/assets/bitmaps/ambassador-arya-aji.png"
-          />
+          <img alt="Aji Arya" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-arya-aji.png" />
           <div>
             <h3 class="h3" id="arya-aji">Aji Arya</h3>
             <span class="block p">Region: Indonesia</span>
             <p class="mb-0 p">
-            Aji Arya, hailing from the enchanting land of Borneo, Indonesia, is
-            a dedicated cloud architect based in Indonesia. Specializing in
-            OpenStack, Kubernetes, and Ceph Project Implementation for
-            university, government, and enterprise, he actively engages with
-            the local open-source Indonesia community, sharing his knowledge
-            through his personal blog and speaking at local conferences.
+              Aji Arya, hailing from the enchanting land of Borneo, Indonesia, is a dedicated cloud architect based in Indonesia.
+              Specializing in OpenStack, Kubernetes, and Ceph Project Implementation for university, government, and enterprise, he actively
+              engages with the local open-source Indonesia community, sharing his knowledge through his personal blog and speaking at local
+              conferences.
             </p>
           </div>
         </div>
@@ -143,22 +132,18 @@ order: 6
 
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img
-            alt="Cheolho Kang"
-            class="rounded-2 to-md:max-w-56 w-full"
-            loading="lazy"
-            src="/assets/bitmaps/ambassador-cheolho.jpg"
-          />
+          <img alt="Cheolho Kang" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-cheolho.jpg" />
           <div>
             <h3 class="h3" id="Cheolho">Cheolho Kang</h3>
             <span class="block p">Region: South Korea</span>
             <p class="mb-0 p">
-              Cheolho Kang is a software engineer at Samsung Electronics, working on the Storage Software Team to develop Ceph. 
-              His work focuses on implementing robust storage solutions for NVMe-oF environments using Ceph. 
-              He is also interested in Seastore for the Crimson project and is actively researching fast recovery techniques, such as NVMe-oF recovery, for petabyte-scale JBoF (Just a Bunch of Flash) systems.
-              He holds a Master’s degree from Seoul National University, where he conducted research on next-generation Non-Volatile Memory systems. 
-              Specifically, he explored the use of emerging NVM technologies to optimize key-value stores such as RocksDB and Redis.
-              In the Korean Ceph community, he leads a Code Walkthrough Study, helping developers gain deeper insights into Ceph’s codebase.
+              Cheolho Kang is a software engineer at Samsung Electronics, working on the Storage Software Team to develop Ceph. His work
+              focuses on implementing robust storage solutions for NVMe-oF environments using Ceph. He is also interested in Seastore for
+              the Crimson project and is actively researching fast recovery techniques, such as NVMe-oF recovery, for petabyte-scale JBoF
+              (Just a Bunch of Flash) systems. He holds a Master’s degree from Seoul National University, where he conducted research on
+              next-generation Non-Volatile Memory systems. Specifically, he explored the use of emerging NVM technologies to optimize
+              key-value stores such as RocksDB and Redis. In the Korean Ceph community, he leads a Code Walkthrough Study, helping
+              developers gain deeper insights into Ceph’s codebase.
             </p>
           </div>
         </div>
@@ -166,19 +151,15 @@ order: 6
 
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img
-            alt="Deepika Upadhyay"
-            class="rounded-2 to-md:max-w-56 w-full"
-            loading="lazy"
-            src="/assets/bitmaps/ambassador-deepika.jpg"
-          />
+          <img alt="Deepika Upadhyay" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-deepika.jpg" />
           <div>
             <h3 class="h3" id="deepika">Deepika Upadhyay</h3>
             <span class="block p">Region: India</span>
             <p class="mb-0 p">
-              Deepika is a Senior Ceph Engineer at CLYSO and is currently focused on Rook and Ceph, with experience in RADOS, RBD, and enhancing tracing efforts for Ceph. 
-              A strong advocate for open source, she is deeply committed to contributing to the Ceph community and is passionate about helping marginalized groups get started in tech. 
-              Outside of work, Deepika enjoys sports, hiking, music, and travel.
+              Deepika is a Senior Ceph Engineer at CLYSO and is currently focused on Rook and Ceph, with experience in RADOS, RBD, and
+              enhancing tracing efforts for Ceph. A strong advocate for open source, she is deeply committed to contributing to the Ceph
+              community and is passionate about helping marginalized groups get started in tech. Outside of work, Deepika enjoys sports,
+              hiking, music, and travel.
             </p>
           </div>
         </div>
@@ -191,10 +172,11 @@ order: 6
             <h3 class="h3" id="yite-gu">Yite Gu</h3>
             <span class="block p">Region: China</span>
             <p class="mb-0 p">
-              Yite Gu runs the Ceph project at ByteDance, as well as the integration project Rook and Ceph-CSI between Ceph and Kubernetes container orchestration systems. 
-              He provides the company with a sustainable iteration and continuous delivery software engineering, and it is in a good cycle. 
-              Yite Started working on Ceph related projects in 2019, maintained a passion for open source software to this day. 
-              He is passionate about contributing code to rados and bluestone, providing free technical support to other enterprises (more than 10) in China that use Ceph storage.
+              Yite Gu runs the Ceph project at ByteDance, as well as the integration project Rook and Ceph-CSI between Ceph and Kubernetes
+              container orchestration systems. He provides the company with a sustainable iteration and continuous delivery software
+              engineering, and it is in a good cycle. Yite Started working on Ceph related projects in 2019, maintained a passion for open
+              source software to this day. He is passionate about contributing code to rados and bluestone, providing free technical support
+              to other enterprises (more than 10) in China that use Ceph storage.
             </p>
           </div>
         </div>
@@ -251,16 +233,11 @@ order: 6
             <h3 class="h3" id="Michiel Manten">Michiel Manten</h3>
             <span class="block p">Region: Benelux (Belgium, Netherlands and Luxemburg)</span>
             <p class="mb-0 p">
-              With over 25 years of IT experience, Michiel Manten has been
-              working with Fairbanks and 42on since 2012, supporting open
-              source teams in high-tech industries from all over the world.
-              Together with Linux, OpenStack and Kubernetes, Ceph is the major
-              focus point of the organizations. Michiel has seen all kinds of
-              Ceph clusters, ranging from terabytes to petabytes, spinning
-              disks or all flash, CephFS, RBD and S3. He was involved with
-              organising parts of the OpenInfra Summit, OpenStack Days, Ceph
-              Days, CloudStack Ceph Days and Cephalocon events and he is always
-              looking forward to keeping Ceph alive and active both in the
+              With over 25 years of IT experience, Michiel Manten has been working with Fairbanks and 42on since 2012, supporting open
+              source teams in high-tech industries from all over the world. Together with Linux, OpenStack and Kubernetes, Ceph is the major
+              focus point of the organizations. Michiel has seen all kinds of Ceph clusters, ranging from terabytes to petabytes, spinning
+              disks or all flash, CephFS, RBD and S3. He was involved with organising parts of the OpenInfra Summit, OpenStack Days, Ceph
+              Days, CloudStack Ceph Days and Cephalocon events and he is always looking forward to keeping Ceph alive and active both in the
               Benelux region and worldwide.
             </p>
           </div>
@@ -279,11 +256,12 @@ order: 6
             <h3 class="h3" id="Frédéric Nass">Frédéric Nass</h3>
             <span class="block p">Region: France</span>
             <p class="mb-0 p">
-              Frédéric is a Senior Ceph Engineer at CLYSO, bringing over 20 years of experience in opensource IT infrastructure. 
-              Originally a civil engineer, he transitioned to IT, specializing in virtualization and storage technologies. 
-              He led Kubernetes and DevOps adoption at the University of Lorraine and has been operating Ceph since 2014, managing petabytes of diverse data including scientific datasets, user files, emails, virtual machines and container storage. 
-              Frédéric speaks at national and international conferences, like at the Red Hat Summit in 2018. 
-              In addition to his main role, Frédéric provides Ceph training to students as a part-time university instructor.
+              Frédéric is a Senior Ceph Engineer at CLYSO, bringing over 20 years of experience in opensource IT infrastructure. Originally
+              a civil engineer, he transitioned to IT, specializing in virtualization and storage technologies. He led Kubernetes and DevOps
+              adoption at the University of Lorraine and has been operating Ceph since 2014, managing petabytes of diverse data including
+              scientific datasets, user files, emails, virtual machines and container storage. Frédéric speaks at national and international
+              conferences, like at the Red Hat Summit in 2018. In addition to his main role, Frédéric provides Ceph training to students as
+              a part-time university instructor.
             </p>
           </div>
         </div>
@@ -291,22 +269,22 @@ order: 6
 
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img alt="Sina Moghaddas" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-sina-moghaddas.jpg" />
+          <img
+            alt="Sina Moghaddas"
+            class="rounded-2 to-md:max-w-56 w-full"
+            loading="lazy"
+            src="/assets/bitmaps/ambassador-sina-moghaddas.jpg"
+          />
           <div>
             <h3 class="h3" id="ray-sun">Sina Moghaddas</h3>
             <span class="block p">Region: Amsterdam</span>
             <p class="mb-0 p">
-              With over a decade of experience in infrastructure design and
-              management, Sina is a seasoned professional specializing in
-              OpenStack and Ceph. He possesses extensive expertise in designing
-              and implementing robust infrastructure solutions, with a focus on
-              OpenStack cloud environments. With a deep understanding of
-              OpenStack's architecture and services, Sina excels in creating
-              scalable and reliable cloud deployments. Their proficiency in
-              Ceph enables them to design and optimize distributed storage
-              systems. With a track record of over 10 years in infrastructure,
-              Sina brings a wealth of experience in delivering high-performance
-              and resilient solutions.
+              With over a decade of experience in infrastructure design and management, Sina is a seasoned professional specializing in
+              OpenStack and Ceph. He possesses extensive expertise in designing and implementing robust infrastructure solutions, with a
+              focus on OpenStack cloud environments. With a deep understanding of OpenStack's architecture and services, Sina excels in
+              creating scalable and reliable cloud deployments. Their proficiency in Ceph enables them to design and optimize distributed
+              storage systems. With a track record of over 10 years in infrastructure, Sina brings a wealth of experience in delivering
+              high-performance and resilient solutions.
             </p>
           </div>
         </div>
@@ -314,53 +292,37 @@ order: 6
 
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img
-            alt="Alvaro Soto"
-            class="rounded-2 to-md:max-w-56 w-full"
-            loading="lazy"
-            src="/assets/bitmaps/ambassador-alvaro-soto.jpg"
-          />
+          <img alt="Alvaro Soto" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-alvaro-soto.jpg" />
           <div>
             <h3 class="h3" id="alvaro-soto">Alvaro Soto</h3>
             <span class="block p">Region: Mexico</span>
             <p class="mb-0 p">
-              I was born in a little town in Chile called Linares. I moved to
-              Mexico at 19 years old to <strike>start</strike> continue my
-              Computer Science Engineering degree (after getting expelled from
-              a university in Chile) and a master's degree in computer science
-              nearly ten years later, mainly because I got bored with people
-              talking about technological concepts without knowing on what
-              nowadays cutting edge platforms are built, and I wanted to work
-              more on research and less explaining.
+              I was born in a little town in Chile called Linares. I moved to Mexico at 19 years old to <strike>start</strike> continue my
+              Computer Science Engineering degree (after getting expelled from a university in Chile) and a master's degree in computer
+              science nearly ten years later, mainly because I got bored with people talking about technological concepts without knowing on
+              what nowadays cutting edge platforms are built, and I wanted to work more on research and less explaining.
             </p>
 
             <p class="mb-0 p">
-              I've worked as a freelancer, implementation engineer, and support
-              engineer for larger and smaller companies in LATAM: Chile,
-              Argentina, Bolivia, Colombia, and Mexico. As a result, today,
-              I dedicate my time to helping companies healthy disengage away
-              from legacy architecture applications and solutions to fully
-              distributed ones with Open Source technologies.
+              I've worked as a freelancer, implementation engineer, and support engineer for larger and smaller companies in LATAM: Chile,
+              Argentina, Bolivia, Colombia, and Mexico. As a result, today, I dedicate my time to helping companies healthy disengage away
+              from legacy architecture applications and solutions to fully distributed ones with Open Source technologies.
             </p>
           </div>
         </div>
       </div>
-      
+
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img
-            alt="Rachana Patel"
-            class="rounded-2 to-md:max-w-56 w-full"
-            loading="lazy"
-            src="/assets/bitmaps/ambassador-rachana.jpg"
-          />
+          <img alt="Rachana Patel" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-rachana.jpg" />
           <div>
             <h3 class="h3" id="Rachana">Rachana Patel</h3>
             <span class="block p">Region: Western North America</span>
             <p class="mb-0 p">
-              I am an open-source enthusiast with a Bachelor’s degree in Computer Engineering and over a decade of experience in software-defined storage. 
-              Since 2016, have been an enthusiastic advocate for Ceph bringing a deep passion for its capabilities and community-driven innovation. 
-              Currently a Technical Program Manager at IBM, I lead complex, multi-phase programs with globally distributed teams, focusing on Agile methodologies, release management, and fostering cross-functional collaboration. 
+              I am an open-source enthusiast with a Bachelor’s degree in Computer Engineering and over a decade of experience in
+              software-defined storage. Since 2016, have been an enthusiastic advocate for Ceph bringing a deep passion for its capabilities
+              and community-driven innovation. Currently a Technical Program Manager at IBM, I lead complex, multi-phase programs with
+              globally distributed teams, focusing on Agile methodologies, release management, and fostering cross-functional collaboration.
               Skilled in process optimization, risk management, technical acumen in automation and performance testing.
             </p>
           </div>
@@ -385,26 +347,24 @@ order: 6
 
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img alt="Humble Devassy" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-humble-devassy.jpg" />
+          <img
+            alt="Humble Devassy"
+            class="rounded-2 to-md:max-w-56 w-full"
+            loading="lazy"
+            src="/assets/bitmaps/ambassador-humble-devassy.jpg"
+          />
           <div>
             <h3 class="h3" id="humble-devassy">Humble Devassy</h3>
             <span class="block p">Region: India</span>
             <p class="mb-0 p">
-            Humble Devassy Chirammal is a Software Architect in the Storage
-            Engineering team at Red Hat. He has more than 17 years of IT
-            experience, and his area of expertise is in understanding the full
-            stack in an ecosystem, with emphasis on architecting solutions
-            based on demand. These days he primarily concentrates on Ceph and
-            its integration to container orchestrator systems like Kubernetes.
-            He is a maintainer of Ceph drivers in Kubernetes and projects like
-            Ceph CSI driver. He has hands-on experience of emerging
-            technologies, such as IaaS and PaaS solutions in Cloud and
-            Containers. In the past, he has worked on intrusion detection
-            systems, Clustering solutions, and Virtualization. He is an open
-            source advocate and actively organizes meetups on CNCF, Openshift/
-            Kubernetes, Storage and Virtualization. He is also an author of the
-            book titled "Mastering KVM Virtualization". He was the main
-            co-ordinator behind first Ceph Day India, 2019.
+              Humble Devassy Chirammal is a Software Architect in the Storage Engineering team at Red Hat. He has more than 17 years of IT
+              experience, and his area of expertise is in understanding the full stack in an ecosystem, with emphasis on architecting
+              solutions based on demand. These days he primarily concentrates on Ceph and its integration to container orchestrator systems
+              like Kubernetes. He is a maintainer of Ceph drivers in Kubernetes and projects like Ceph CSI driver. He has hands-on
+              experience of emerging technologies, such as IaaS and PaaS solutions in Cloud and Containers. In the past, he has worked on
+              intrusion detection systems, Clustering solutions, and Virtualization. He is an open source advocate and actively organizes
+              meetups on CNCF, Openshift/ Kubernetes, Storage and Virtualization. He is also an author of the book titled "Mastering KVM
+              Virtualization". He was the main co-ordinator behind first Ceph Day India, 2019.
             </p>
           </div>
         </div>
@@ -429,45 +389,49 @@ order: 6
       </div>
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img alt="Thomas Bennett" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-thomas-bennett.jpg" />
+          <img
+            alt="Thomas Bennett"
+            class="rounded-2 to-md:max-w-56 w-full"
+            loading="lazy"
+            src="/assets/bitmaps/ambassador-thomas-bennett.jpg"
+          />
           <div>
-            <h3 class="h3" id="ray-sun"> Thomas Bennett</h3>
+            <h3 class="h3" id="ray-sun">Thomas Bennett</h3>
             <span class="block p">Region: South Africa</span>
             <p class="mb-0 p">
-              Based in Cape Town, South Africa, Tom cofounded Tsolo.io, a company focused on Ceph-driven storage solutions. With more than two
-              decades of experience, he architects and deploys petascale storage systems across research and enterprise environments. He was 
-              part of the engineering team that built the MeerKAT radio telescope backend, supporting large-scale scientific infrastructure at
-              the forefront of radio astronomy.
-              
-              Tom has worked with Ceph since the Luminous release and has extensive hands-on experience designing, building, and operating
-              large-scale clusters. His expertise spans RGW (object), RBD (block), and CephFS deployments, with a focus on operational 
-              resilience and performance at scale. He has presented at Ceph community events, including Ceph Days, Cephalocon, and Ceph Tech Talks.
-              
-              As a Ceph Ambassador, he aims to grow and support the Ceph community in South Africa and across the region, fostering collaboration and
-              knowledge-sharing around production Ceph operations.
+              Based in Cape Town, South Africa, Tom cofounded Tsolo.io, a company focused on Ceph-driven storage solutions. With more than
+              two decades of experience, he architects and deploys petascale storage systems across research and enterprise environments. He
+              was part of the engineering team that built the MeerKAT radio telescope backend, supporting large-scale scientific
+              infrastructure at the forefront of radio astronomy. Tom has worked with Ceph since the Luminous release and has extensive
+              hands-on experience designing, building, and operating large-scale clusters. His expertise spans RGW (object), RBD (block),
+              and CephFS deployments, with a focus on operational resilience and performance at scale. He has presented at Ceph community
+              events, including Ceph Days, Cephalocon, and Ceph Tech Talks. As a Ceph Ambassador, he aims to grow and support the Ceph
+              community in South Africa and across the region, fostering collaboration and knowledge-sharing around production Ceph
+              operations.
             </p>
           </div>
         </div>
       </div>
       <div class="pt-0 section">
         <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-          <img alt="Thomas Bennett" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-ansgar-jazdzewski.png" />
+          <img
+            alt="Thomas Bennett"
+            class="rounded-2 to-md:max-w-56 w-full"
+            loading="lazy"
+            src="/assets/bitmaps/ambassador-ansgar-jazdzewski.png"
+          />
           <div>
-            <h3 class="h3" id="ray-sun"> Ansgar Jazdzewski</h3>
+            <h3 class="h3" id="ray-sun">Ansgar Jazdzewski</h3>
             <span class="block p">Region: Germany</span>
             <p class="mb-0 p">
-              Ansgar is a Systems and Storage Engineer at Hetzner Cloud, where he works on object storage built on Ceph's RADOS Gateway (RGW).
-
-              He has been working with Ceph for over a decade, and his journey started even before the Argonaut release, back when he was running 
-              RBD alongside Ganeti. Since then, he has touched pretty much every corner of Ceph, including operating CephFS at multi-petabyte scale 
-              as part of a large Samba NAS project.
-              
-
-              As a Ceph Ambassador for Germany, Ansgar brings the service provider perspective into the conversation. What it actually looks like 
-              to run Ceph at scale, day in and day out, for thousands of users. It's a viewpoint that doesn't always get enough spotlight, and there's 
-              a lot of value in sharing the real operational lessons, the hard-won fixes, and the things you only learn by doing.
-
-              He loves talking about this stuff, whether that's at a meetup, a workshop, or just a good conversation over a coffee at a conference.
+              Ansgar is a Systems and Storage Engineer at Hetzner Cloud, where he works on object storage built on Ceph's RADOS Gateway
+              (RGW). He has been working with Ceph for over a decade, and his journey started even before the Argonaut release, back when he
+              was running RBD alongside Ganeti. Since then, he has touched pretty much every corner of Ceph, including operating CephFS at
+              multi-petabyte scale as part of a large Samba NAS project. As a Ceph Ambassador for Germany, Ansgar brings the service
+              provider perspective into the conversation. What it actually looks like to run Ceph at scale, day in and day out, for
+              thousands of users. It's a viewpoint that doesn't always get enough spotlight, and there's a lot of value in sharing the real
+              operational lessons, the hard-won fixes, and the things you only learn by doing. He loves talking about this stuff, whether
+              that's at a meetup, a workshop, or just a good conversation over a coffee at a conference.
             </p>
           </div>
         </div>

--- a/src/en/community/ambassadors/index.html
+++ b/src/en/community/ambassadors/index.html
@@ -10,10 +10,10 @@ order: 6
     <h2 class="h1">Ceph Ambassadors</h2>
 
     <p class="p">
-      The Ceph Ambassadors are community managers who support Ceph communities within their region with the responsibilities listed below.
-      Get to know the team and contact your supporting ambassador by reaching out to us through the Ceph community. If you are not a part of
-      the Ceph Community, please <a class="a" href="https://ceph.io/en/community/connect/">connect with us</a>. You can read the note from
-      the latest Ceph Ambassador meeting <a class="a" href="https://pad.ceph.com/p/ceph-ambassadors-meeting">here</a>.
+      Ceph Ambassadors support regional communities in the below ways. Get to know the team and contact your supporting ambassador by
+      reaching out to us through the Ceph community. If you are not a part of the Ceph Community, please
+      <a class="a" href="https://ceph.io/en/community/connect/">connect with us</a>. You can read the notes from the latest Ceph Ambassador
+      meeting <a class="a" href="https://pad.ceph.com/p/ceph-ambassadors-meeting">here</a>.
 
       <span class="block p">What we can help with:</span>
     </p>


### PR DESCRIPTION
Feature request was to add individual links to each profile, would make it easier to share 
An example link would look like : https://ceph.io/en/community/ambassadors/#aji-arya

None of the body text changed, the first commit was a formatter/linter running. Second commit has the added link changes, and the names are red now too. 

The href tag (e.g `href="#gaurav-sitlani`) determines the link, I defaulted to first-last. 


<img width="1229" height="1094" alt="image" src="https://github.com/user-attachments/assets/9de2f17b-e805-4588-9ab3-bfaca95c55c0" />
