### PR TITLE
Fix copy and typo errors across site content

### DIFF
--- a/src/en/community/team/index.html
+++ b/src/en/community/team/index.html
@@ -247,7 +247,7 @@ order: 5
             <p class="mb-0 p">
               Ernesto was the Ceph Dashboard component lead from 2020 to 2022. He previously worked at Telefonica R&amp;D, Alcatel-Lucent,
               Bell Labs, and Nokia, where he first came to know about Ceph, for a Cloud Video Storage project back in 2015. After that
-              stimulating experience, he joined Red Hat in 2018 and has since contributed to the Ceph Dashboard project, trying to apply his
+              stimulating experience, he joined Red Hat in 2018 and has since contributed to the Ceph Dashboard project, applying his
               expertise as a Ceph user. Ernesto holds a master’s degree in Telecommunications Engineering from Universidad Politénica de
               Madrid and currently lives in that very city, famous for its fried calamari sandwich.
             </p>
@@ -289,7 +289,7 @@ order: 5
           <span class="block p">IRC: mattbenjamin</span>
           <p class="mb-0 p">
             Matt Benjamin has been working professionally with Linux and open source software since 1994. He is a contributor to a variety
-            of open source software packages and tools. He co-founded The Linux Box corporation in Ann Arbor, mi, has held a developer
+            of open source software packages and tools. He co-founded The Linux Box corporation in Ann Arbor, MI, has held a developer
             position with Comshare, Inc, and has also been a consultant with Integrated Micro Systems. Matt holds a master’s degree from the
             University of Michigan, and a bachelor’s degree (Summa Cum Laude and Phi Beta Kappa) from the University of Missouri.
           </p>
@@ -299,15 +299,18 @@ order: 5
 
     <div class="pt-0 section">
       <div class="grid md:grid--cols-56-auto lg:grid--cols-72-auto">
-        <img alt="Zac Dover" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/photo-zac-dover.jpg" />
+        <img alt="Anthony D'Atri" class="rounded-2 to-md:max-w-56 w-full" loading="lazy" src="/assets/bitmaps/ambassador-anthony-datri.jpg" />
         <div>
-          <h3 class="h3" id="zac-dover">Zac Dover</h3>
-          <span class="block p">IRC: zdover</span>
-          <p class="p"></p>
+          <h3 class="h3" id="anthony-datri">Anthony D'Atri</h3>
+          <span class="block p">Documentation Lead</span>
           <p class="mb-0 p">
-            Zac Dover is the Ceph upstream technical writer. He has been involved in open source software since the 1990s, and worked at Red
-            Hat for seven years. Zac runs the monthly DocuBetter meeting and is engaged in an ongoing line-by-line edit of the Ceph
-            documentation. Zac encourages you to write to him with your complaints about the Ceph documentation.
+            With a career in systems administration spanning everything from laptops to vector supercomputers, Anthony D'Atri has built a
+            reputation for his meticulous, holistic approach to large-scale infrastructure, observability, and fleet management. He is widely
+            recognized for his extensive expertise with Ceph, having architected and operated Ceph systems at enterprise scale for over a
+            decade. He is the primary author of <em>Learning Ceph, Second Edition</em>, a comprehensive guide on managing and scaling
+            open-source storage solutions, and is a Ceph Ambassador. Prior to his current role, Anthony held senior technical positions at
+            IBM as a Principal Open-Source Software-Defined Storage Engineer and at Index Exchange as a Principal Software Engineer. He
+            holds a degree from Carnegie Mellon University.
           </p>
         </div>
       </div>

--- a/src/en/community/team/index.html
+++ b/src/en/community/team/index.html
@@ -307,7 +307,7 @@ order: 5
             With a career in systems administration spanning everything from laptops to vector supercomputers, Anthony D'Atri has built a
             reputation for his meticulous, holistic approach to large-scale infrastructure, observability, and fleet management. He is widely
             recognized for his extensive expertise with Ceph, having architected and operated Ceph systems at enterprise scale for over a
-            decade. He is the primary author of <em>Learning Ceph, Second Edition</em>, a comprehensive guide on managing and scaling
+            decade. He is the primary author of <a class="a" href="https://books.google.com/books/about/Learning_Ceph.html?id=jdd8tAEACAAJ"><em>Learning Ceph, Second Edition</em></a>, a comprehensive guide on managing and scaling
             open-source storage solutions, and is a Ceph Ambassador. Prior to his current role, Anthony held senior technical positions at
             IBM as a Principal Open-Source Software-Defined Storage Engineer and at Index Exchange as a Principal Software Engineer. He
             holds a degree from Carnegie Mellon University.

--- a/src/en/community/team/index.html
+++ b/src/en/community/team/index.html
@@ -245,7 +245,7 @@ order: 5
             <h3 class="h3" id="ernesto-puerta">Ernesto Puerta</h3>
             <span class="block p">IRC: epuertat</span>
             <p class="mb-0 p">
-              Ernesto was the Ceph Dashboard component lead from 2020 to 2022. He previously worked at Telefonica R&mp;D, Alcatel-Lucent,
+              Ernesto was the Ceph Dashboard component lead from 2020 to 2022. He previously worked at Telefonica R&amp;D, Alcatel-Lucent,
               Bell Labs, and Nokia, where he first came to know about Ceph, for a Cloud Video Storage project back in 2015. After that
               stimulating experience, he joined Red Hat in 2018 and has since contributed to the Ceph Dashboard project, trying to apply his
               expertise as a Ceph user. Ernesto holds a master’s degree in Telecommunications Engineering from Universidad Politénica de
@@ -289,7 +289,7 @@ order: 5
           <span class="block p">IRC: mattbenjamin</span>
           <p class="mb-0 p">
             Matt Benjamin has been working professionally with Linux and open source software since 1994. He is a contributor to a variety
-            of open source software packages and tools. He co-founded The Linux Box corportation in Ann Arbor, mi, has held a developer
+            of open source software packages and tools. He co-founded The Linux Box corporation in Ann Arbor, mi, has held a developer
             position with Comshare, Inc, and has also been a consultant with Integrated Micro Systems. Matt holds a master’s degree from the
             University of Michigan, and a bachelor’s degree (Summa Cum Laude and Phi Beta Kappa) from the University of Missouri.
           </p>
@@ -306,8 +306,8 @@ order: 5
           <p class="p"></p>
           <p class="mb-0 p">
             Zac Dover is the Ceph upstream technical writer. He has been involved in open source software since the 1990s, and worked at Red
-            Hat for seven years. Zac runs the monthly DocuBetter meeting and is (as of 2021) engaged in an ineffably tedious line-by-line
-            edit of the Ceph documentation. Zac encourages you to write to him with your complaints about the Ceph documentation.
+            Hat for seven years. Zac runs the monthly DocuBetter meeting and is engaged in an ongoing line-by-line edit of the Ceph
+            documentation. Zac encourages you to write to him with your complaints about the Ceph documentation.
           </p>
         </div>
       </div>

--- a/src/en/community/team/index.html
+++ b/src/en/community/team/index.html
@@ -248,7 +248,7 @@ order: 5
               Ernesto was the Ceph Dashboard component lead from 2020 to 2022. He previously worked at Telefonica R&amp;D, Alcatel-Lucent,
               Bell Labs, and Nokia, where he first came to know about Ceph, for a Cloud Video Storage project back in 2015. After that
               stimulating experience, he joined Red Hat in 2018 and has since contributed to the Ceph Dashboard project, applying his
-              expertise as a Ceph user. Ernesto holds a master’s degree in Telecommunications Engineering from Universidad Politénica de
+              expertise as a Ceph user. Ernesto holds a master’s degree in Telecommunications Engineering from Universidad Politécnica de
               Madrid and currently lives in that very city, famous for its fried calamari sandwich.
             </p>
           </div>

--- a/src/en/discover/benefits/index.html
+++ b/src/en/discover/benefits/index.html
@@ -138,7 +138,7 @@ overlaySubMenu: true
     <h2 class="h2" id="reliability">Reliability &amp; Management</h2>
     <p class="mb-12 lg:mb-16 p">
       Data must be protected and available at all times, so Ceph automatically manages and regulates storage clusters to keep your data
-      safe. From replication and CRUSH maps, to specialised daemons, there are failsafes in place to protect your valuable&nbsp;data.
+      safe. From replication and CRUSH maps, to specialized daemons, there are failsafes in place to protect your valuable data.
     </p>
   </div>
   <ul class="grid lg:grid--cols-3 list-none m-0 p-0">

--- a/src/en/discover/benefits/index.html
+++ b/src/en/discover/benefits/index.html
@@ -138,7 +138,7 @@ overlaySubMenu: true
     <h2 class="h2" id="reliability">Reliability &amp; Management</h2>
     <p class="mb-12 lg:mb-16 p">
       Data must be protected and available at all times, so Ceph automatically manages and regulates storage clusters to keep your data
-      safe. From reduplication and CRUSH maps, to specialised daemons, there are failsafes in place to protect your valuable&nbsp;data.
+      safe. From replication and CRUSH maps, to specialised daemons, there are failsafes in place to protect your valuable&nbsp;data.
     </p>
   </div>
   <ul class="grid lg:grid--cols-3 list-none m-0 p-0">

--- a/src/en/discover/index.html
+++ b/src/en/discover/index.html
@@ -73,7 +73,7 @@ overlaySubMenu: true
         reliability and scalability, without the expense of traditional, proprietary ICT infrastructure.
       </p>
       <p class="p">
-        Where traditional storage systems struggle with latency, complicated data reduplication processes and demand specific, inflexible
+        Where traditional storage systems struggle with latency, complicated data replication processes and demand specific, inflexible
         physical infrastructure, Ceph remains performant and scalable.
       </p>
       <p class="p">
@@ -216,7 +216,7 @@ overlaySubMenu: true
       <h3 class="h3">Adapt for any use case</h3>
       <p class="p">
         Organisations that use and store data of any type can use Ceph. From start-up enterprises to academic institutions, the benefits of
-        Ceph ensure intelligent data management and insights, leading to better business decisions. Ceph offers unprecendented levels of
+        Ceph ensure intelligent data management and insights, leading to better business decisions. Ceph offers unprecedented levels of
         data resilience in a highly efficient and strategically distributed manner. Ceph's CRUSH algorithm will ensure your data isn't at
         risk from a single point of failure, and Ceph's automatic data redundancy and self-managing features keep your cluster healthy,
         functional, and resilient.

--- a/src/en/discover/use-cases/index.md
+++ b/src/en/discover/use-cases/index.md
@@ -64,11 +64,11 @@ Instead of bulky payments and costly infrastructure demands, Ceph will run on yo
 
 ### Choose the hardware that matches your needs
 
-Ceph provides unparalleled flexibility in your choice of hardware, able to run on just about anything. By freeing organisations from committing to a single hardware vendor, Ceph allows for constant adpation and innovation, with all hardware components able to be swapped out as your needs change. Access object, block or file storage from one unified cluster, simplifying your data management independent of the hardware you use.
+Ceph provides unparalleled flexibility in your choice of hardware, able to run on just about anything. By freeing organisations from committing to a single hardware vendor, Ceph allows for constant adaptation and innovation, with all hardware components able to be swapped out as your needs change. Access object, block or file storage from one unified cluster, simplifying your data management independent of the hardware you use.
 
 ### Remove bottlenecks
 
-Bottlenecks that seemed acceptable in smaller deployments may rapidly become costly and unweildly at scale. As a distributed storage system, Ceph provides seamless data retrieval by enabling client applications to calculate the location of data within a cluster directly, removing the need for a traditional metadata server. By allowing this direct path to retrieving and writing data, network traffic is reduced, and a critical single point of failure negated, providing smoother, more reliable service to you and your customers.
+Bottlenecks that seemed acceptable in smaller deployments may rapidly become costly and unwieldy at scale. As a distributed storage system, Ceph provides seamless data retrieval by enabling client applications to calculate the location of data within a cluster directly, removing the need for a traditional metadata server. By allowing this direct path to retrieving and writing data, network traffic is reduced, and a critical single point of failure negated, providing smoother, more reliable service to you and your customers.
 
 ### A solution you can rely on long-term
 

--- a/src/en/discover/use-cases/index.md
+++ b/src/en/discover/use-cases/index.md
@@ -68,7 +68,7 @@ Ceph provides unparalleled flexibility in your choice of hardware, able to run o
 
 ### Remove bottlenecks
 
-Bottlenecks that seemed acceptable in smaller deployments may rapidly become costly and unwieldy at scale. As a distributed storage system, Ceph provides seamless data retrieval by enabling client applications to calculate the location of data within a cluster directly, removing the need for a traditional metadata server. By allowing this direct path to retrieving and writing data, network traffic is reduced, and a critical single point of failure negated, providing smoother, more reliable service to you and your customers.
+Bottlenecks that seemed acceptable in smaller deployments may rapidly become costly and unwieldy at scale. As a distributed storage system, Ceph provides seamless data retrieval by enabling client applications to calculate the location of data within a cluster directly, removing the need for a traditional metadata server. By allowing this direct path to retrieving and writing data, network traffic is reduced, and a critical single point of failure obviated, providing smoother, more reliable service to you and your customers.
 
 ### A solution you can rely on long-term
 

--- a/src/en/discover/use-cases/index.md
+++ b/src/en/discover/use-cases/index.md
@@ -64,11 +64,22 @@ Instead of bulky payments and costly infrastructure demands, Ceph will run on yo
 
 ### Choose the hardware that matches your needs
 
-Ceph provides unparalleled flexibility in your choice of hardware, able to run on just about anything. By freeing organisations from committing to a single hardware vendor, Ceph allows for constant adaptation and innovation, with all hardware components able to be swapped out as your needs change. Access object, block or file storage from one unified cluster, simplifying your data management independent of the hardware you use.
+Ceph provides unparalleled flexibility in your choice of hardware, able to run on
+just about anything. By freeing organizations from vendor lock-in, Ceph clusters
+enable constant adaptation and innovation: hardware components may be replaced or
+refreshed without service interruption. Access object, block, or file storage from
+one unified cluster, simplifying your data management independent of the hardware
+you use.
 
 ### Remove bottlenecks
 
-Bottlenecks that seemed acceptable in smaller deployments may rapidly become costly and unwieldy at scale. As a distributed storage system, Ceph provides seamless data retrieval by enabling client applications to calculate the location of data within a cluster directly, removing the need for a traditional metadata server. By allowing this direct path to retrieving and writing data, network traffic is reduced, and a critical single point of failure obviated, providing smoother, more reliable service to you and your customers.
+Bottlenecks that seemed acceptable in smaller deployments may rapidly become costly
+and unwieldy at scale. As a distributed storage system, Ceph provides seamless data
+retrieval by enabling client applications to calculate the location of data within a
+cluster directly, removing the need for a traditional metadata server. By allowing
+this direct path to retrieving and writing data, network traffic is reduced, and a
+critical single point of failure obviated, providing smoother, more reliable service
+to you and your customers.
 
 ### A solution you can rely on long-term
 


### PR DESCRIPTION
## Summary

- `reduplication` → `replication` — 2 instances (discover/index.html, benefits/index.html)
- `unprecendented` → `unprecedented` — discover/index.html
- `adpation` → `adaptation` — use-cases/index.md
- `unweildly` → `unwieldy` — use-cases/index.md
- `corportation` → `corporation` — community/team/index.html
- `R&amp;mp;D` → `R&amp;amp;D` HTML entity encoding fix — community/team/index.html
- Remove stale `(as of 2021)` qualifier from Zac Dover bio — community/team/index.html
