### PR TITLE
Adding header image for Ceph Days Zurich 2026

### DIFF
--- a/src/en/community/events/2026/ceph-days-zurich/index.md
+++ b/src/en/community/events/2026/ceph-days-zurich/index.md
@@ -4,7 +4,7 @@ date: 2026-10-14
 end: 2026-10-14
 location: Zuerich, Switzerland
 venue: University Zurich, Rämistrasse 59, CH-8006 Zurich 
-image: "/assets/bitmaps/ceph-days.png"
+image: "/assets/bitmaps/events/2026/ceph-days-zurich/banner.png"
 sponsors: CLYSO
 tags:
   - ceph days


### PR DESCRIPTION
Hi this PR changes the header image for Ceph Days Zurich 2026. 
It shows Zurich and the Ceph logo instead of the generic Ceph event image. 