### PR TITLE
CD London slides fix - typos

### DIFF
--- a/src/en/community/events/2026/ceph-days-london/index.md
+++ b/src/en/community/events/2026/ceph-days-london/index.md
@@ -269,7 +269,7 @@ This talk describes the physical relocation of a live Ceph cluster between datac
   <tr>
    <td>4:00 PM
    </td>
-   <td><strong>Ceph Dedup for RGW: Scalable Object Deduplication (<a href="/assets/pdfs/events/2026/ceph-days-london/ceph-dedup-for-rgw.pdf" target="_blank">Slides</a>" target="_blank">Slides</a>)</strong>
+   <td><strong>Ceph Dedup for RGW: Scalable Object Deduplication (<a href="/assets/pdfs/events/2026/ceph-days-london/ceph-dedup-for-rgw.pdf" target="_blank">Slides</a>)</strong>
 <p>
 In this talk, we will present Ceph Dedup for RGW objects, a scale-out deduplication feature that runs on RGW servers and efficiently identifies and eliminates duplicate full RGW objects. The feature is available in the main upstream code today and is targeted for the Tentacle release as a tech-preview.
    </td>

--- a/src/en/community/events/2026/ceph-days-london/index.md
+++ b/src/en/community/events/2026/ceph-days-london/index.md
@@ -162,7 +162,7 @@ This session explores the architectural shifts required to allow clients to bypa
   <tr>
      <td>12:00 PM
    </td>
-   <td><strong>Scaling CephFS MDS for Front Developer Workspaces on Kubernetes (<a href="/assets/pdfs/events/2026/ceph-days-london/caling-cephfs-mds.pdf" target="_blank">Slides</a>)</strong>
+   <td><strong>Scaling CephFS MDS for Front Developer Workspaces on Kubernetes (<a href="/assets/pdfs/events/2026/ceph-days-london/scaling-cephfs-mds.pdf" target="_blank">Slides</a>)</strong>
 <p>
 Modern frontend development ecosystems, particularly Node.js, are notorious for generating enormous metadata footprints. A single 'node_modules' directory can easily contain over 100,000 files and deeply nested directory trees. Now multiply that by dozens or hundreds of concurrent developer workspaces, all backed by CephFS, and you have a perfect storm hitting your MDS layer.
  


### PR DESCRIPTION
Removing target and strong tags from the presentation name
Fixing typo for file name of pdf file