### PR TITLE
Expand Contribute, Code, Documentation, and Vision pages

### DIFF
--- a/src/en/developers/code/index.html
+++ b/src/en/developers/code/index.html
@@ -4,27 +4,101 @@ order: 2
 ---
 
 <section class="section">
-  <h1 class="h1">{{ title }}</h1>
-
-  <h2 class="h2 mb-12 lg:mb-16">Start using Ceph today</h2>
+  <h1 class="h1 mb-12 lg:mb-16">{{ title }}</h1>
   <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
     <div>
       <p class="standout">
-        Fork and clone the Ceph Github repository today. If you prefer to work with a Ceph tarball, you'll find many Ceph tarballs at the
-        tarball link on this page.
+        The Ceph codebase lives on GitHub and is open to contributions from anyone. Every patch, review, and design discussion happens in
+        the open.
       </p>
+      <p class="p">
+        Fork the repository to start exploring the source, or read the Contributor Guide first to learn how the project is organised, how
+        patches flow, and where your skills fit.
+      </p>
+      <a class="button" href="https://github.com/ceph/ceph">View on GitHub</a>
     </div>
     <div class="bg-grey-300 p-5 rounded-2">
-      <h3 class="h3">Ceph Github Repository</h3>
-      <p class="p">
-        The Ceph Github repository contains the code for the Ceph project.
+      <h2 class="h3">Get the source</h2>
+      <p class="mb-8 lg:mb-12 p">
+        Clone the repository from GitHub to track development as it happens, download the source of any official release as a tarball, or
+        install pre-built packages.
       </p>
-      <a class="button mb-8 lg:mb-12" href="https://github.com/ceph/ceph">Ceph Github Repository</a>
-      <h3 class="h3">Ceph Tarballs</h3>
-      <p class="p">
-        Ceph tarballs are available at the link here.
-      </p>
-      <a class="button" href="https://download.ceph.com/tarballs">Ceph Tarball Downloads</a>
+      <div class="flex flex--gap-4 lg:flex--gap-6 flex--justify-between flex--wrap">
+        <div class="relative text-center">
+          <img alt="" class="block mb-2 mx-auto w-12" src="/assets/svgs/icon-git-blue-red.svg" />
+          <a class="a link-cover" href="https://github.com/ceph/ceph">GIT</a>
+        </div>
+        <div class="relative text-center">
+          <img alt="" class="block mb-2 mx-auto w-12" src="/assets/svgs/icon-tar-blue-red.svg" />
+          <a class="a link-cover" href="https://download.ceph.com/tarballs/">Tarball</a>
+        </div>
+        <div class="relative text-center">
+          <img alt="" class="block mb-2 mx-auto w-12" src="/assets/svgs/icon-package-blue-red.svg" />
+          <a class="a link-cover" href="https://docs.ceph.com/en/latest/install/get-packages/">Packages</a>
+        </div>
+      </div>
     </div>
+  </div>
+</section>
+
+<section class="bg-grey-300 section section--full">
+  <div class="wrapper">
+    <h2 class="h2 mb-12 lg:mb-16 text-center">Key components</h2>
+    <ul class="grid lg:grid--cols-3 list-none m-0 p-0">
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-rados-blue-red.svg" />
+        <h3 class="h3">RADOS</h3>
+        <p class="p">
+          The Reliable Autonomic Distributed Object Store is Ceph's foundation, handling data placement, replication, and recovery across
+          the cluster with the CRUSH algorithm. Every higher-level interface is built on top of it.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/architecture/">Architecture guide</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-reliable-blue-red.svg" />
+        <h3 class="h3">OSD</h3>
+        <p class="p">
+          The Object Storage Daemon runs on every storage node and handles reads, writes, replication, and recovery. Crimson, Ceph's
+          next-generation OSD, targets improved performance on modern NVMe hardware.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/dev/osd_internals/">OSD internals</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-crush-blue-red.svg" />
+        <h3 class="h3">Monitor &amp; Manager</h3>
+        <p class="p">
+          Monitors maintain the authoritative cluster map through distributed consensus, while the Manager collects metrics and hosts
+          pluggable modules for dashboards, alerting, and orchestration. Manager modules are a popular place to start contributing in Python.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/mgr/">Manager modules</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-object-blue-red.svg" />
+        <h3 class="h3">RGW</h3>
+        <p class="p">
+          The RADOS Gateway provides S3- and Swift-compatible object storage, with multi-site replication, lifecycle policies, bucket
+          notifications, and IAM-compatible access control.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/radosgw/">Object Gateway guide</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-block-blue-red.svg" />
+        <h3 class="h3">RBD</h3>
+        <p class="p">
+          The RADOS Block Device provides thin-provisioned block storage with snapshots, cloning, and replication. RBD images back virtual
+          machines and container volumes through the Linux kernel driver and QEMU.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/rbd/">Block Device guide</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-files-blue-red.svg" />
+        <h3 class="h3">CephFS &amp; MDS</h3>
+        <p class="p">
+          CephFS is a POSIX-compliant distributed file system. Its Metadata Server manages the file system namespace and scales horizontally
+          with multiple active MDS daemons across large directory trees.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/cephfs/">File System guide</a>
+      </li>
+    </ul>
   </div>
 </section>

--- a/src/en/developers/contribute/index.html
+++ b/src/en/developers/contribute/index.html
@@ -3,11 +3,111 @@ title: Contribute
 order: 3
 ---
 
-<section class="section section--full">
-  <div class="wrapper">
-    <h1 class="h1">{{ title }}</h1>
+<section class="section">
+  <h1 class="h1 mb-12 lg:mb-16">{{ title }}</h1>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        Ceph is built by a global community. Whether you write code, improve documentation, file bugs, or help others in the forums, every
+        contribution matters.
+      </p>
+      <p class="p">
+        The Contributor Guide covers everything you need to get started: setting up a development environment, the patch workflow, coding
+        standards, and how review works.
+      </p>
+      <a class="button" href="https://docs.ceph.com/en/latest/dev/developer_guide/">Read the Contributor Guide</a>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h2 class="h3">How contributions work</h2>
+      <ol class="ol">
+        <li class="mb-4">Fork the <a class="a" href="https://github.com/ceph/ceph">ceph/ceph</a> repository on GitHub.</li>
+        <li class="mb-4">Create a branch and make your changes, keeping commits focused with clear messages.</li>
+        <li class="mb-4">Open a pull request against <code>main</code>, or against a stable branch for backports.</li>
+        <li class="mb-4">CI runs automated tests. Address any failures before requesting review.</li>
+        <li class="mb-4">A component lead or maintainer reviews your patch. Engage with feedback and iterate.</li>
+        <li class="mb-0">Once approved, your patch is merged. Backports to stable releases are tracked separately.</li>
+      </ol>
+    </div>
+  </div>
+</section>
 
-    <a class="button" href="https://docs.ceph.com/en/latest/dev/developer_guide">Ceph Contributor Guide</a>
-    <p>{% YouTube 't5UIehZ1oLs', 'Getting Started with Ceph Development' %}</p>
+<section class="bg-grey-300 section section--full">
+  <div class="wrapper">
+    <h2 class="h2 mb-12 lg:mb-16 text-center">Ways to contribute</h2>
+    <ul class="grid lg:grid--cols-3 list-none m-0 p-0">
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-code-blue-red.svg" />
+        <h3 class="h3">Code</h3>
+        <p class="p">
+          Fix bugs, implement features, or improve performance across any of Ceph's subsystems. All development happens in the open on
+          GitHub, and the Contributor Guide walks you through the patch workflow, CI requirements, and review process.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/dev/developer_guide/">Contributor Guide</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-documentation-blue-red.svg" />
+        <h3 class="h3">Documentation</h3>
+        <p class="p">
+          The Ceph documentation lives alongside the code and welcomes improvements at any level, from fixing typos to writing new guides.
+          The DocuBetter meeting is a regular forum for documentation contributors to coordinate and get feedback.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/dev/documenting/">Documentation guide</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-benefits-blue-red.svg" />
+        <h3 class="h3">Testing &amp; bug reports</h3>
+        <p class="p">
+          Running Ceph and hitting a bug? Filing a detailed issue on the Ceph tracker is one of the most valuable things you can do. Include
+          your Ceph version, cluster configuration, and the steps to reproduce.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://tracker.ceph.com/">Ceph issue tracker</a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="section">
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <h2 class="h2">Get involved</h2>
+      <ul class="list-none p-0">
+        <li class="mb-6">
+          <strong class="block p">Ceph Developer Monthly call</strong>
+          <p class="mb-0 p">
+            A monthly video call open to all contributors. Agendas and connection details are posted to the
+            <a class="a" href="https://lists.ceph.io/postorius/lists/dev.ceph.io/">dev mailing list</a>.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Mailing lists</strong>
+          <p class="mb-0 p">
+            Development discussion happens on the <a class="a" href="https://lists.ceph.io/postorius/lists/dev.ceph.io/">dev</a> list;
+            operational questions and community support on
+            <a class="a" href="https://lists.ceph.io/postorius/lists/ceph-users.ceph.io/">ceph-users</a>.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Chat &amp; events</strong>
+          <p class="mb-0 p">
+            Join the community on Slack, follow meetups and events, and find every channel on the
+            <a class="a" href="/{{ locale }}/community/connect/">connect page</a>.
+          </p>
+        </li>
+        <li class="mb-0">
+          <strong class="block p">Code of Conduct</strong>
+          <p class="mb-0 p">
+            All Ceph community spaces are governed by the <a class="a" href="/{{ locale }}/code-of-conduct/">Ceph Code of Conduct</a>.
+            Please read it before participating.
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div>
+      <h2 class="h2">Your first patch</h2>
+      <p class="p">
+        New to Ceph development? This walkthrough covers setting up a development environment and submitting your first patch.
+      </p>
+      {% YouTube 't5UIehZ1oLs', 'Getting Started with Ceph Development' %}
+    </div>
   </div>
 </section>

--- a/src/en/discover/vision/index.html
+++ b/src/en/discover/vision/index.html
@@ -1,52 +1,258 @@
 ---
-layout: content-simple
 title: Vision
 order: 3
+overlaySubMenu: true
 ---
 
 <h1 class="h1 visually-hidden">{{ title }}</h1>
 
-<section class="section" class="pt-0 section--full">
-  <div class="pb-0 section wrapper">
-    <h2 class="h2 mb-12 lg:mb-16" id="get-ceph">Get Ceph</h2>
-    <div class="grid lg:grid--cols-2 lg:max-w-256 grid--gap-14 lg:grid--gap-28">
-      <div>
-        <h2 class="h2">The future of storage</h2>
-
-        <h3 class="h3">
-          Ceph is an industry leader for effortless data storage and management at any scale, independent of hardware reliance
-        </h3>
-
-        <ul>
-          <li>Ceph enables organizations to work with data at any scale, and any budget</li>
-          <li>Ceph offers unified block, file and object storage, allowing for more efficient data backup and interopability</li>
-          <li>Ceph prioritises data durability and availability through 'self-healing' monitoring and data placement algorithms</li>
-        </ul>
-
-        <h2 class="h2">Open source innovation</h2>
-
-        <h3 class="h3">As an open source platform with a community spanning the globe, Ceph always stays one step ahead.</h3>
-
-        The worldwide network behind Ceph ensures continual development, growth and improvement. Without the confines of a proprietary
-        business model, Ceph’s community is free to create and explore, innovating outside of traditional development structures. With Ceph,
-        you can take your imagined solutions, and construct tangible technology. Want to be at the forefront of innovation?
-
-        <a class="a" href="../../community/">Join the community</a>
-
-        Stay up-to-date with Ceph’s news and community to find out how we will evolve…
-
-        <a class="a" href="../../news/">News</a>
-      </div>
-      <div>
-        <h2 class="h2 mb-12 lg:mb-16">Ceph Is Democratising Storage</h2>
-
-        <p>From academic research clusters to hyperscale cloud infrastructure, organizations worldwide use Ceph to break free from
-        proprietary storage constraints. Ceph's hardware-independent, open source model puts enterprise-grade storage within reach of
-        any organization, at any scale.</p>
-
-        <a class="a block mb-6" href="../../discover/use-cases/">See Ceph in action</a>
-        <a class="button" href="../../foundation/members/">Meet the Foundation members</a>
-      </div>
+<section class="bg-navy section section--full">
+  <div class="wrapper">
+    <div class="max-w-224 mx-auto py-16 text-center">
+      <h2 class="color-white h1">The future of storage is open.</h2>
+      <p class="color-white standout">
+        Ceph's vision is simple: every storage problem should be solvable with open source software. One platform for object, block, and
+        file storage that runs on any hardware, scales to any size, and belongs to no single vendor.
+      </p>
+      <p class="color-white mb-0 standout">
+        That vision now drives a new generation of Ceph: rebuilt for flash, native to Kubernetes, and steered in the open by the community
+        that depends on it.
+      </p>
     </div>
+  </div>
+</section>
+
+<ul class="sub-menu">
+  <li>
+    <a href="#performance"><img alt="" src="/assets/svgs/icon-performance-blue-red.svg" />Next-generation performance</a>
+  </li>
+  <li>
+    <a href="#cloud-native"><img alt="" src="/assets/svgs/icon-container-blue-red.svg" />Cloud-native storage</a>
+  </li>
+  <li>
+    <a href="#open-source"><img alt="" src="/assets/svgs/icon-innovation-blue-red.svg" />Democratizing storage</a>
+  </li>
+  <li>
+    <a href="#roadmap"><img alt="" src="/assets/svgs/icon-contribute-blue-red.svg" />An open roadmap</a>
+  </li>
+</ul>
+
+<section class="section">
+  <div class="max-w-192 mx-auto text-center">
+    <h2 class="h2" id="performance">Next-generation performance</h2>
+    <p class="mb-12 lg:mb-16 p">
+      Storage hardware has been transformed: NVMe drives serve millions of I/O operations per second, networks move hundreds of gigabits,
+      and CPUs gain cores faster than software can use them. Ceph is being rebuilt so that open source storage leads on this hardware,
+      rather than merely running on it.
+    </p>
+  </div>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <h3 class="h3">Crimson and Seastore</h3>
+      <p class="p">
+        Crimson is Ceph's next-generation OSD, rebuilt from the ground up on the Seastar framework: a shared-nothing, one-thread-per-core
+        design that keeps work on the CPU core that owns it and avoids the locks, context switches, and kernel overhead that limit today's
+        storage daemons.
+      </p>
+      <p class="p">
+        Crimson shipped its first technology preview in the Squid release, and Tentacle added Seastore, Crimson's purpose-built object store
+        designed for flash rather than spinning disks. The goal is a drop-in replacement for the classic OSD: speaking the same librados
+        protocol, joining the same clusters, with Seastore as its native backend.
+      </p>
+      <a class="a block mb-4" href="/{{ locale }}/developers/crimson/">Explore the Crimson project</a>
+      <a class="a" href="/{{ locale }}/news/blog/2025/crimson-seastore-vs-classic/">Read the early Crimson benchmarks</a>
+    </div>
+    <div>
+      <h3 class="h3">Faster with every release</h3>
+      <p class="p">
+        The performance push spans the whole platform. The Tentacle (v20) release introduced fast erasure coding, making erasure-coded pools
+        a practical choice for block and file workloads, alongside a faster BlueStore write-ahead log and improved compression.
+      </p>
+      <p class="p">
+        Ceph's NVMe over TCP gateway presents block storage to any standard NVMe initiator: highly available, SAN-style access over ordinary
+        Ethernet with no proprietary hardware. And the community keeps proving what open source can do at scale, including a 10-petabyte
+        all-flash cluster sustaining a terabyte per second.
+      </p>
+      <a class="a block mb-4" href="/{{ locale }}/news/blog/2024/ceph-a-journey-to-1tibps/">How Ceph reached 1 TiB/s</a>
+      <a class="a" href="/{{ locale }}/news/blog/2025/tentacle-fastec-performance-updates/">Fast erasure coding in Tentacle</a>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <div class="max-w-192 mx-auto text-center">
+    <h2 class="h2" id="cloud-native">Cloud-native storage</h2>
+    <p class="mb-12 lg:mb-16 p">
+      Modern infrastructure is built on Kubernetes, and Ceph is built to live there: deployed, managed, and consumed through the same APIs
+      as the platforms it serves.
+    </p>
+  </div>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <h3 class="h3">Native to Kubernetes</h3>
+      <p class="p">
+        Rook, a graduated Cloud Native Computing Foundation project, is the Ceph documentation's preferred way to run Ceph on Kubernetes: an
+        operator that deploys, configures, and manages entire clusters through Kubernetes APIs. The Ceph CSI driver provisions block and
+        file volumes for workloads dynamically, with snapshots, cloning, and volume expansion built in.
+      </p>
+      <p class="p">
+        Beyond Kubernetes, cephadm deploys and manages every Ceph daemon in containers: the same declarative, self-managing operational
+        model from bare metal to cloud. Wherever your platform runs, Ceph runs the way your platform expects.
+      </p>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h3 class="h3">Cloud-native resources</h3>
+      <ul class="list-none p-0">
+        <li class="mb-6">
+          <strong class="block p">Rook</strong>
+          <p class="mb-0 p">
+            The Kubernetes operator for Ceph: production-ready orchestration of file, block, and object storage. Visit
+            <a class="a" href="https://rook.io/">rook.io</a> to get started.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Ceph CSI</strong>
+          <p class="mb-0 p">
+            Dynamic provisioning of RBD and CephFS volumes for Kubernetes workloads, maintained in the open on
+            <a class="a" href="https://github.com/ceph/ceph-csi">GitHub</a>.
+          </p>
+        </li>
+        <li class="mb-0">
+          <strong class="block p">Block storage for containers</strong>
+          <p class="mb-0 p">
+            See how RBD backs Kubernetes volumes in the
+            <a class="a" href="https://docs.ceph.com/en/latest/rbd/rbd-kubernetes/">documentation</a>, or read about all three storage
+            interfaces on the <a class="a" href="/{{ locale }}/discover/technology/">technology page</a>.
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <div class="max-w-192 mx-auto text-center">
+    <h2 class="h2" id="open-source">Democratizing storage</h2>
+    <p class="mb-12 lg:mb-16 p">
+      Ceph exists to do for storage what Linux did for computing: turn essential infrastructure into open technology that anyone can use,
+      study, improve, and operate at any scale.
+    </p>
+  </div>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <h3 class="h3">Open by design</h3>
+      <p class="p">
+        Ceph runs on commodity hardware from any vendor, is licensed as free and open source software, and is developed entirely in public.
+        There is no proprietary edition, no locked feature tier, and no exit penalty: the code powering the largest research and cloud
+        clusters in the world is the same code anyone can download today.
+      </p>
+      <p class="standout">
+        "A guiding vision for Ceph is to be the state of the art for reliable, scale-out storage, and to do so with 100% open source."
+      </p>
+      <p class="p">Sage Weil, Ceph creator, at the founding of the Ceph Foundation</p>
+    </div>
+    <div>
+      <h3 class="h3">A neutral home</h3>
+      <p class="p">
+        The Ceph Foundation, a directed fund under the Linux Foundation since 2018, gives the project a neutral home. The Foundation
+        supports the community with funding, events, and outreach, while technical direction stays with the community itself through the
+        Ceph Steering Committee and its elected Executive Council.
+      </p>
+      <p class="p">
+        From academic research clusters to hyperscale cloud infrastructure, organizations worldwide use Ceph to break free from proprietary
+        storage constraints.
+      </p>
+      <a class="a block mb-6" href="/{{ locale }}/discover/use-cases/">See Ceph in action</a>
+      <a class="button" href="/{{ locale }}/foundation/members/">Meet the Foundation members</a>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <div class="max-w-192 mx-auto text-center">
+    <h2 class="h2" id="roadmap">An open roadmap</h2>
+    <p class="mb-12 lg:mb-16 p">
+      Ceph's future is not decided behind closed doors. It is planned, debated, and built in public, and anyone can take part.
+    </p>
+  </div>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <h3 class="h3">How Ceph moves forward</h3>
+      <p class="p">
+        A new named stable release ships roughly every year, and each series is supported for about two years. The current stable release is
+        Tentacle (v20), and the next, Umbrella, is already in development.
+      </p>
+      <p class="p">
+        Each cycle begins with the Ceph Developer Summit, where contributors plan the next release component by component. Open developer
+        calls, the public issue tracker, and component boards on GitHub carry that plan through the year, in full view of the community.
+      </p>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h3 class="h3">Follow and shape the roadmap</h3>
+      <ul class="list-none p-0">
+        <li class="mb-6">
+          <strong class="block p">Roadmap</strong>
+          <p class="mb-0 p">
+            The trackers and project boards the community plans with, collected on the
+            <a class="a" href="/{{ locale }}/developers/roadmap/">roadmap page</a>.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Contribute</strong>
+          <p class="mb-0 p">
+            Your first patch, the developer calls, and how review works: start on the
+            <a class="a" href="/{{ locale }}/developers/contribute/">contribute page</a>.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Mailing lists</strong>
+          <p class="mb-0 p">
+            Development discussion happens in the open on the
+            <a class="a" href="https://lists.ceph.io/postorius/lists/dev.ceph.io/">dev mailing list</a>.
+          </p>
+        </li>
+        <li class="mb-0">
+          <strong class="block p">Events</strong>
+          <p class="mb-0 p">
+            Ceph Days, developer summits, and meetups around the world are listed on the
+            <a class="a" href="/{{ locale }}/community/events/">events page</a>.
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="bg-grey-300 section section--full">
+  <div class="wrapper">
+    <h2 class="h2 text-center">Discover more</h2>
+    <ul class="grid lg:grid--cols-3 list-none mb-0 p-0">
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img class="mb-4 w-12" src="/assets/svgs/icon-rados-blue-red.svg" alt="" />
+        <h3 class="h3">Technology</h3>
+        <p class="p">
+          Object, block, and file storage built on RADOS: see how CRUSH placement, self-healing, and unified storage interfaces work under
+          the hood.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/technology/">See how Ceph works</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img class="mb-4 w-12" src="/assets/svgs/icon-customers-blue-red.svg" alt="" />
+        <h3 class="h3">Use cases</h3>
+        <p class="p">
+          Businesses, academic institutions, global organizations and more streamline their data storage and scale to the exabyte level with
+          Ceph.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/use-cases/">See how Ceph is used</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img class="mb-4 w-12" src="/assets/svgs/icon-meetup-blue-red.svg" alt="" />
+        <h3 class="h3">Community</h3>
+        <p class="p">
+          Join the developers and operators building the future of open source storage: events, mailing lists, chat channels, and more.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/community/">Meet the Ceph community</a>
+      </li>
+    </ul>
   </div>
 </section>

--- a/src/en/users/documentation/index.html
+++ b/src/en/users/documentation/index.html
@@ -6,17 +6,92 @@ order: 2
 <section class="section">
   <h1 class="h1 mb-12 lg:mb-16">{{ title }}</h1>
   <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
-    <p class="mb-0 standout">The Ceph Foundation believes that all storage problems should be solvable with open-source software.</p>
-    <div class="bg-grey-300 p-5 rounded-2">
-      <p class="p">The upstream Ceph documentation is linked below.</p>
-      <p class="p">
-        The Ceph Install Guide describes how to deploy a Ceph cluster. The cephadm guide describes how to use the cephadm utility to manage
-        your Ceph cluster. If you are consulting the documentation to learn the rules and customs that govern making a pull request against
-        the ceph/ceph Github repository, read the Developer Guide. For more in-depth information about the nature of Ceph, see the
-        Architecture Guide on the page linked below.
+    <div>
+      <p class="standout">
+        The Ceph documentation covers everything from first-time installation to deep architectural reference, all at
+        <a class="a" href="https://docs.ceph.com/en/latest/">docs.ceph.com</a>.
       </p>
-      <p class="p">Once you are on the Ceph documentation site, use the left pane to navigate to the guide you want.</p>
-      <a class="button" href="https://docs.ceph.com/en/latest/">Ceph Documentation</a>
+      <p class="p">
+        Whether you're deploying your first cluster or tuning an existing one, each major guide is self-contained, so you can jump straight to the
+        section relevant to your task, or use the quick links to get there faster.
+      </p>
+      <a class="button" href="https://docs.ceph.com/en/latest/">Go to Ceph Documentation</a>
     </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h2 class="h3">Quick links</h2>
+      <ul class="list-none p-0">
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/install/">Installation Guide</a>: deploy your first cluster
+        </li>
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/cephadm/">Cephadm Guide</a>: manage Ceph with the official orchestrator
+        </li>
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/rados/">RADOS &amp; Configuration</a>: tune and operate your cluster
+        </li>
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/radosgw/">Object Storage (RGW)</a>: S3 and Swift interfaces
+        </li>
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/rbd/">Block Storage (RBD)</a>: block devices for VMs and containers
+        </li>
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/cephfs/">File System (CephFS)</a>: POSIX-compliant distributed filesystem
+        </li>
+        <li class="mb-4 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/architecture/">Architecture Guide</a>: how Ceph works under the hood
+        </li>
+        <li class="mb-0 p">
+          <a class="a" href="https://docs.ceph.com/en/latest/dev/developer_guide/">Developer Guide</a>: contributing code and patches
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="bg-grey-300 section section--full">
+  <div class="wrapper">
+    <h2 class="h2 mb-12 lg:mb-16 text-center">What's in the documentation</h2>
+    <ul class="grid lg:grid--cols-3 list-none m-0 p-0">
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-ceph-deploy-blue-red.svg" />
+        <h3 class="h3">Installation &amp; deployment</h3>
+        <p class="p">
+          Step-by-step guides for deploying Ceph with Cephadm (the recommended path), Rook for Kubernetes environments, or manual
+          installation, including hardware recommendations, network configuration, and cluster bootstrap.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/install/">Installing Ceph</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-performance-blue-red.svg" />
+        <h3 class="h3">Operations &amp; administration</h3>
+        <p class="p">
+          Day-two operations: monitoring cluster health, adding and removing OSDs, upgrading between releases, performance tuning, disaster
+          recovery, and browser-based management with the Ceph Dashboard.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="https://docs.ceph.com/en/latest/rados/">Cluster operations</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 rounded-2">
+        <h3 class="h3">Storage interfaces</h3>
+        <p class="mb-8 lg:mb-12 p">
+          A dedicated guide for each way to consume Ceph storage: S3- and Swift-compatible object storage, block devices for VMs and
+          containers, and the POSIX-compliant CephFS file system.
+        </p>
+        <div class="flex flex--gap-4 lg:flex--gap-6 flex--justify-between flex--wrap">
+          <div class="relative text-center">
+            <img alt="" class="block mb-2 mx-auto w-12" src="/assets/svgs/icon-object-blue-red.svg" />
+            <a class="a link-cover" href="https://docs.ceph.com/en/latest/radosgw/">Object</a>
+          </div>
+          <div class="relative text-center">
+            <img alt="" class="block mb-2 mx-auto w-12" src="/assets/svgs/icon-block-blue-red.svg" />
+            <a class="a link-cover" href="https://docs.ceph.com/en/latest/rbd/">Block</a>
+          </div>
+          <div class="relative text-center">
+            <img alt="" class="block mb-2 mx-auto w-12" src="/assets/svgs/icon-files-blue-red.svg" />
+            <a class="a link-cover" href="https://docs.ceph.com/en/latest/cephfs/">File</a>
+          </div>
+        </div>
+      </li>
+    </ul>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Four thin pages have been expanded, completing the Content Expansion track, styled with the site's existing design language: white icon cards on full-width grey bands (clickable, with hover shadows via `link-cover`), navy hero bands with `sub-menu` anchor navigation, two-column intro sections with side panels, and icon quick-link rows, matching the Benefits, Technology, Developers hub, and Getting Started pages.

**Contribute page** (was: 1 button + YouTube embed)
- Two-column intro: standout copy + Contributor Guide CTA, with the six-step patch workflow (fork → branch → PR → CI → review → merge) in a side panel
- "Ways to contribute" band: Code, Documentation, and Testing & bug reports as clickable icon cards
- "Get involved": Ceph Developer Monthly call, mailing lists (dev, ceph-users), chat/events via the connect page, and the Code of Conduct
- Kept the getting-started YouTube video, paired with "Get involved" under "Your first patch"

**Code page** (was: GitHub link + tarball link)
- Two-column intro: GitHub CTA + "Get the source" panel with icon quick links (Git, Tarball, Packages)
- "Key components" band: RADOS, OSD, Monitor/Manager, RGW, RBD, CephFS/MDS as clickable icon cards, each linking to its documentation

**Documentation page** (was: single link to docs.ceph.com)
- Two-column intro with a quick-links panel to 8 major doc sections
- "What's in the documentation" band: Installation & deployment and Operations & administration as clickable icon cards, plus a Storage interfaces card with Object/Block/File icon links

**Vision page** (was: 52 lines built around the retired 2021 PDF report)
- Full rewrite into a genuine vision statement, structured like the Benefits/Technology pages: navy hero, sub-menu anchors, four themed sections, closing "Discover more" band
- Themes: next-generation performance (Crimson OSD & Seastore, the flash-native era), cloud-native direction (Rook, Ceph-CSI, cephadm), democratizing storage (open governance under the Ceph Foundation), and an open roadmap (public planning via CDM, Developer Summits, tracker and GitHub Projects)
- Links to the relocated Crimson project page (`/en/developers/crimson/`), the Roadmap page, current performance blog posts, use cases, and Foundation members
- Also fixes the page's long-standing markup bugs (duplicate `class` attribute, unwrapped text nodes) and moves it off `content-simple` onto the standard `content` layout
- All factual claims (Crimson/Seastore status, Tentacle-era performance work, Rook/CNCF status, governance) were verified against 2025–2026 primary sources: docs.ceph.com, the ceph.io blog, and project repositories; release references are line-level only (no minor versions that would age)

The branch is rebased onto current `main` (so the Vision rewrite builds on the recent PDF-removal fix rather than conflicting with it).

## Test plan

- [x] `npx eleventy` (2.0.1) + full asset build pass; rendered HTML inspected for all four pages
- [x] All external links verified to return HTTP 200 (docs.ceph.com, rook.io, lists.ceph.io, tracker.ceph.com, download.ceph.com)
- [x] All internal links resolve to built pages (including `/en/developers/crimson/`, `/en/developers/roadmap/`, `/en/foundation/members/`)
- [x] Sub-menu anchors on Vision match section `id`s
- [x] Contribute/Code/Documentation pages byte-identical through the rebase (no regressions)
- [ ] Visual check of the four pages at desktop and mobile widths
