### PR TITLE
Fix leftover links from Tentacle Award page move

### DIFF
--- a/ansible/roles/deploy/templates/redirects.j2
+++ b/ansible/roles/deploy/templates/redirects.j2
@@ -11,6 +11,10 @@
       return 301 /en/users/getting-started;
   }
 
+  location ~ ^/en/community/team/tentacle-award/?$ {
+      return 301 /en/community/tentacle-award;
+  }
+
   location ~ ^/community/blog/?$ {
       return 301 /en/news/blog;
   }

--- a/src/en/community/team/index.html
+++ b/src/en/community/team/index.html
@@ -17,7 +17,7 @@ order: 5
 
     <p class="mb-12 p">
       Find out more about each key player and their area of expertise, or see members who have received the
-      <a class="a" href="https://move-tentacle-awards.ceph.io/en/community/tentacle-award">tentacle award!</a>
+      <a class="a" href="/{{ locale }}/community/tentacle-award/">tentacle award!</a>
     </p>
 
     <div class="grid lg:grid--cols-2">

--- a/src/en/community/team/tentacle-award.html
+++ b/src/en/community/team/tentacle-award.html
@@ -1,6 +1,7 @@
 ---
 title: Tentacle Award
 tags: 'support'
+eleventyExcludeFromCollections: true
 permalink: '/{{ locale }}/community/team/tentacle-award/index.html'
 ---
 <!doctype html>

--- a/src/en/community/team/tentacle-award.html
+++ b/src/en/community/team/tentacle-award.html
@@ -1,0 +1,17 @@
+---
+title: Tentacle Award
+tags: 'support'
+permalink: '/{{ locale }}/community/team/tentacle-award/index.html'
+---
+<!doctype html>
+<html lang="{{ locale }}">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tentacle Award</title>
+    <meta http-equiv="refresh" content="0; url=/{{ locale }}/community/tentacle-award/" />
+    <link rel="canonical" href="/{{ locale }}/community/tentacle-award/" />
+  </head>
+  <body>
+    <p>This page has moved to <a href="/{{ locale }}/community/tentacle-award/">/{{ locale }}/community/tentacle-award/</a>.</p>
+  </body>
+</html>

--- a/src/en/news/blog/2022/community-newsletter-february/index.md
+++ b/src/en/news/blog/2022/community-newsletter-february/index.md
@@ -29,7 +29,7 @@ The team recognizes the outstanding contributions of some former and present mem
 
 ![Patrick Donnelly with the Tentacle Award](images/tentacle-award-patrick-donnelly.jpg)
 
-[See all award members](https://ceph.io/en/community/team/tentacle-award/)
+[See all award members](https://ceph.io/en/community/tentacle-award/)
 
 ## Ceph Blog
 


### PR DESCRIPTION
## Summary

The Tentacle Award page was moved from `/community/team/tentacle-award/` to `/community/tentacle-award/`, but two links were left behind:

- The **Team page** linked to the branch preview domain (`https://move-tentacle-awards.ceph.io/...`) instead of the live site path. It now points to `/{{ locale }}/community/tentacle-award/`
- The **February 2022 community newsletter** still linked the old `/community/team/tentacle-award/` path, which now 404s

Also adds a small meta-refresh stub at the old URL so external backlinks (newsletters were emailed with the old link) redirect to the new page instead of 404ing. The stub is tagged `support` so it stays out of navigation collections.

