### PR TITLE
Fix dead and outdated external links found in link audit

### DIFF
--- a/src/en/foundation/members/index.md
+++ b/src/en/foundation/members/index.md
@@ -40,23 +40,23 @@ order: 3
   <a href="https://www.digitalocean.com/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-digitalocean.png" /></a>
   <a href="http://iss-integration.com/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-intelligent-systems.png" /></a>  
   <a href="https://www.osnexus.com/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-osnexus.png" /></a>
-  <a href="https://www.ovh.com/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-ovh.png" /></a>
+  <a href="https://www.ovhcloud.com/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-ovh.png" /></a>
   <a href="https://sonyinteractive.com/en/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/sony-interactive-entertainment-llc.svg" /></a>
 </div>
 
 ### Associate Members
 
 <div class="grid grid--align-center grid--cols-2 md:grid--cols-3 md:w-3-4">
-  <a href="http://www.bu.com/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-boston-university.png" /></a>
+  <a href="https://www.bu.edu/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-boston-university.png" /></a>
   <a href="https://home.cern/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-cern.png" /></a>
   <a href="http://cross.ucsc.edu/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-cross.png" /></a>
   <a href="https://www.rc.fas.harvard.edu/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-fas.png" /></a>
   <a href="https://grnet.gr/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-grnet.png" /></a>
   <a href="http://www.monash.edu/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-monash.png" /></a>
-  <a href="http://www.ska.ac.za/about/sarao/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-sarao.png" /></a>
-  <a href="https://openinfra.dev" rel="noreferrer noopener" target="_blank"><img alt="OpenInfra Foundation" loading="lazy" src="/assets/bitmaps/logo-openinfra.png" /></a>
+  <a href="https://www.sarao.ac.za/about/sarao/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-sarao.png" /></a>
+  <a href="https://openinfra.org" rel="noreferrer noopener" target="_blank"><img alt="OpenInfra Foundation" loading="lazy" src="/assets/bitmaps/logo-openinfra.png" /></a>
   <a href="https://www6.slac.stanford.edu/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-slac.svg" /></a>
-  <a href="https://stfc.ukri.org/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-science-and-technology-council.png" /></a>
+  <a href="https://www.ukri.org/councils/stfc/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-science-and-technology-council.png" /></a>
   <a href="https://switch.ch/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-switch.png" /></a>
   <a href="http://www.osris.org/" rel="noreferrer noopener" target="_blank"><img alt="" loading="lazy" src="/assets/bitmaps/logo-umich.png" /></a>
 </div>

--- a/src/en/news/blog/2022/install-ceph-in-a-raspberrypi-4-cluster/index.md
+++ b/src/en/news/blog/2022/install-ceph-in-a-raspberrypi-4-cluster/index.md
@@ -133,7 +133,7 @@ Please consider enabling telemetry to help improve Ceph:
 
 For more information see:
 
-        https://docs.ceph.com/docs/pacific/mgr/telemetry/
+        https://docs.ceph.com/en/pacific/mgr/telemetry/
 
 Bootstrap complete.
 ```


### PR DESCRIPTION
## Summary

Ran an automated link audit over the telemetry references, developer pages, and the Foundation Members page (65 unique external URLs checked). Fixes for what came back broken or retired:

**Broken (verified dead):**
- Boston University member link pointed at `www.bu.com`, which does not resolve; the correct domain is `www.bu.edu`
- Raspberry Pi cluster blog post (2022) linked `docs.ceph.com/docs/pacific/mgr/telemetry/`, which 404s because the legacy `/docs/` scheme redirect map omits pacific; working path is `/en/pacific/mgr/telemetry/`

**Retired domains (currently only work via redirect):**
- SARAO: `ska.ac.za` → `sarao.ac.za`
- STFC: retired `stfc.ukri.org` subdomain → `ukri.org/councils/stfc/`
- OpenInfra Foundation: `openinfra.dev` → `openinfra.org`
- OVH: rebranded as OVHcloud, `ovh.com` → `ovhcloud.com`

**Audit notes (no change needed):** telemetry-public.ceph.com, the Grafana x-ray dashboard, and the device telemetry dashboard are all healthy. `telemetry.ceph.com/report` returns 405 on GET but that is the submission endpoint quoted in a config snippet, which is expected. Bloomberg and Monash return 403 to bots but load fine in a browser.

## Test plan

- [ ] Each updated link opens the intended organization's page
- [ ] Foundation Members page renders unchanged apart from link targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
