### PR TITLE
Fix Slack card markup on Connect page

### DIFF
--- a/src/en/community/connect/index.html
+++ b/src/en/community/connect/index.html
@@ -8,9 +8,11 @@ order: 4
     <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
     <div>
     <div class="bg-grey-300 mb-8 lg:mb-12 p-5 rounded-2">
-      <h3 class="h2">Ceph Foundation Slack</h3>
-      <a class="button" href="https://join.slack.com/t/ceph-storage/shared_invite/zt-453jwr8e9-wu~QvC0jcH4oZBug3oMgdg">Subscribe</a>
-     <p lass="p mb-0">
+      <h3 class="h3 mb-4">Ceph Foundation Slack</h3>
+      <div class="mb-4">
+        <a class="button" href="https://join.slack.com/t/ceph-storage/shared_invite/zt-453jwr8e9-wu~QvC0jcH4oZBug3oMgdg">Subscribe</a>
+      </div>
+     <p class="p mb-0">
       Join thousands of operators and developers learning and discussing Ceph, the open-source de facto standard storage system.
       </p>
   </div>


### PR DESCRIPTION
## Summary

Scope reduced per Foundation guidance: IRC is community-run rather than Foundation-supported, so ceph.io does not promote it (the docs Get Involved page continues to list the channels). This PR now only fixes the Slack card markup on the Connect page:

- `<p lass="p mb-0">` to `<p class="p mb-0">` (the paragraph styling classes were silently not applied)
- Heading level corrected from `h3 class="h2"` to `h3 class="h3"` with consistent spacing
- Subscribe button wrapped to match the page's other cards

No IRC content is added.

## Test plan

- [x] Slack card renders with proper paragraph styling and heading scale
- [x] No IRC mention anywhere on the page
