### PR TITLE
Add Documentation dropdown to the primary navigation

### DIFF
--- a/src/_data/docsNav.js
+++ b/src/_data/docsNav.js
@@ -1,0 +1,19 @@
+// Links shown in the site header's Documentation dropdown.
+// Mirrors the top-level sections of docs.ceph.com.
+module.exports = [
+  { title: 'Installation', url: 'https://docs.ceph.com/en/latest/install/' },
+  { title: 'Cephadm', url: 'https://docs.ceph.com/en/latest/cephadm/' },
+  {
+    title: 'Cluster Operations',
+    url: 'https://docs.ceph.com/en/latest/rados/',
+  },
+  {
+    title: 'Object Storage (RGW)',
+    url: 'https://docs.ceph.com/en/latest/radosgw/',
+  },
+  { title: 'Block Storage (RBD)', url: 'https://docs.ceph.com/en/latest/rbd/' },
+  {
+    title: 'File System (CephFS)',
+    url: 'https://docs.ceph.com/en/latest/cephfs/',
+  },
+];

--- a/src/_includes/components/navigation-primary.njk
+++ b/src/_includes/components/navigation-primary.njk
@@ -9,6 +9,20 @@
           {{ item.title }}
         </a>
       </li>
+      {%- if item.url == '/' + locale + '/developers/' -%}
+        <li class="nav-primary__dropdown">
+          <a href="https://docs.ceph.com/">
+            Documentation<span aria-hidden="true" class="nav-primary__caret"></span>
+          </a>
+          <ul class="nav-primary__dropdown-menu">
+            {%- for link in docsNav -%}
+              <li>
+                <a href="{{ link.url }}">{{ link.title }}</a>
+              </li>
+            {%- endfor -%}
+          </ul>
+        </li>
+      {%- endif -%}
     {%- endfor -%}
   </ul>
 </nav>

--- a/src/css/component.nav-primary.css
+++ b/src/css/component.nav-primary.css
@@ -88,3 +88,73 @@
     color: var(--color-red-600);
   }
 }
+
+/* ---------- dropdown (Documentation) ---------- */
+
+.nav-primary__caret {
+  border-left: var(--size-1) solid transparent;
+  border-right: var(--size-1) solid transparent;
+  border-top: var(--size-1) solid currentColor;
+  display: inline-block;
+  height: 0;
+  margin-left: var(--size-1);
+  vertical-align: middle;
+  width: 0;
+}
+
+@media (--mq-to-lg) {
+  .nav-primary__dropdown-menu {
+    list-style: none;
+    margin: var(--size-4) 0 0;
+    padding: 0 0 0 var(--size-4);
+  }
+
+  .nav-primary__dropdown-menu li {
+    margin-bottom: var(--size-4);
+  }
+}
+
+@media (--mq-lg) {
+  .nav-primary__dropdown {
+    position: relative;
+  }
+
+  .nav-primary__dropdown-menu {
+    background-color: var(--color-white);
+    border: 1px solid var(--color-grey-500);
+    border-radius: var(--size-2);
+    box-shadow: var(--shadow-black);
+    display: none;
+    left: calc(-1 * var(--size-5));
+    list-style: none;
+    margin: 0;
+    min-width: var(--size-56);
+    padding: var(--size-3) 0;
+    position: absolute;
+    top: 100%;
+    z-index: 11;
+  }
+
+  .nav-primary__dropdown:hover .nav-primary__dropdown-menu,
+  .nav-primary__dropdown:focus-within .nav-primary__dropdown-menu {
+    display: block;
+  }
+
+  .nav-primary__dropdown-menu a,
+  .home .nav-primary__dropdown-menu a {
+    color: var(--color-gunmetal);
+    display: block;
+    padding: var(--size-2) var(--size-5);
+    white-space: nowrap;
+  }
+
+  .nav-primary__dropdown-menu a:hover,
+  .home .nav-primary__dropdown-menu a:hover {
+    color: var(--color-red-500);
+  }
+
+  .nav-primary__dropdown-menu a:active,
+  .home .nav-primary__dropdown-menu a:active {
+    color: var(--color-red-600);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a top-level Documentation item to the primary navigation (between Developers and Community), modeled on python.org's Documentation menu.

- The item itself links to https://docs.ceph.com/
- On desktop, hovering or keyboard-focusing the item reveals a dropdown with six shortcuts mirroring the docs sections: Installation, Cephadm, Cluster Operations, Object Storage (RGW), Block Storage (RBD), File System (CephFS)
- In the off-canvas mobile menu the six links render as an always-visible indented list
- The dropdown is CSS-only (hover + focus-within), styled with existing tokens (white panel, grey border, shadow, rounded corners) so it stays readable over the transparent home-page header
- Link data lives in a new `src/_data/docsNav.js` so the list can be edited without touching templates
