### PR TITLE
Add Why Ceph, Cloud native, FAQ, and History pages

### DIFF
--- a/src/assets/svgs/icon-container-white-red.svg
+++ b/src/assets/svgs/icon-container-white-red.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48" viewBox="0 0 48 48" aria-hidden="true" focusable="false">
+  <title>Container</title>
+  <g stroke-linecap="square" stroke-width="2" fill="none" stroke="#FFF" stroke-linejoin="miter" stroke-miterlimit="10">
+    <rect x="11" y="11" width="10" height="10" stroke="#EB1414" />
+    <rect x="27" y="11" width="10" height="10" stroke="#FFF" />
+    <rect x="11" y="27" width="10" height="10" stroke="#FFF" />
+    <rect x="27" y="27" width="10" height="10" stroke="#EB1414" />
+    <rect x="4" y="4" width="40" height="40" />
+  </g>
+</svg>

--- a/src/css/component.timeline.css
+++ b/src/css/component.timeline.css
@@ -1,0 +1,67 @@
+/* ---------- COMPONENT timeline ---------- */
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+.timeline::before {
+  background: var(--color-grey-500);
+  bottom: 0;
+  content: "";
+  left: var(--size-1);
+  position: absolute;
+  top: var(--size-1);
+  width: var(--size-px);
+}
+
+.timeline__item {
+  padding-bottom: var(--size-10);
+  padding-left: var(--size-10);
+  position: relative;
+}
+
+.timeline__item:last-child {
+  padding-bottom: 0;
+}
+
+.timeline__item::before {
+  background: var(--color-red-500);
+  border-radius: 50%;
+  content: "";
+  height: var(--size-3);
+  left: calc(var(--size-1) - var(--size-3) / 2 + var(--size-px) / 2);
+  position: absolute;
+  top: var(--size-1);
+  width: var(--size-3);
+}
+
+.timeline__year {
+  color: var(--color-navy);
+  font-weight: var(--font-weight-semibold);
+  margin: 0 0 var(--size-2);
+}
+
+@media (--mq-lg) {
+  .timeline::before {
+    left: calc(var(--size-24) + var(--size-14) / 2);
+  }
+
+  .timeline__item {
+    column-gap: var(--size-14);
+    display: grid;
+    grid-template-columns: var(--size-24) minmax(0, 1fr);
+    padding-left: 0;
+  }
+
+  .timeline__item::before {
+    left: calc(var(--size-24) + var(--size-14) / 2 - var(--size-3) / 2 + var(--size-px) / 2);
+  }
+
+  .timeline__year {
+    margin: 0;
+    text-align: right;
+  }
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -43,6 +43,7 @@
 @import "component.site-header.css";
 @import "component.social-shares.css";
 @import "component.sub-menu.css";
+@import "component.timeline.css";
 @import "component.tint.css";
 @import "component.tooltip.css";
 

--- a/src/en/discover/index.html
+++ b/src/en/discover/index.html
@@ -136,11 +136,12 @@ overlaySubMenu: true
       </p>
       <a class="a inline-block mb-8 lg:mb-12" href="/{{ locale }}/foundation/members/">Meet the Ceph foundation members</a>
       <h3 class="h3">No vendor lock-in</h3>
-      <p class="mb-0 p">
+      <p class="p">
         Gone are the days of expensive IT infrastructure and zero compatibility. Ceph can be applied to off-the-shelf hardware, supported
         and successfully utilised within a heterogeneous environment. With Ceph, you don’t need to invest in costly hardware, instead you
         have the freedom to choose what works for your business.
       </p>
+      <a class="a" href="/{{ locale }}/discover/why-ceph/">Why choose Ceph</a>
     </div>
     <div>
       <h3 class="h3">Backed by the community</h3>
@@ -215,19 +216,20 @@ overlaySubMenu: true
       <h3 class="h3">Adapt for any use case</h3>
       <p class="p">
         Organisations that use and store data of any type can use Ceph. From start-up enterprises to academic institutions, the benefits of
-        Ceph ensure intelligent data management and insights, leading to better business decisions. Ceph offers unprecedented levels of
-        data resilience in a highly efficient and strategically distributed manner. Ceph's CRUSH algorithm will ensure your data isn't at
-        risk from a single point of failure, and Ceph's automatic data redundancy and self-managing features keep your cluster healthy,
+        Ceph ensure intelligent data management and insights, leading to better business decisions. Ceph offers unprecedented levels of data
+        resilience in a highly efficient and strategically distributed manner. Ceph's CRUSH algorithm will ensure your data isn't at risk
+        from a single point of failure, and Ceph's automatic data redundancy and self-managing features keep your cluster healthy,
         functional, and resilient.
       </p>
       <a class="a inline-block mb-8 lg:mb-12" href="/{{ locale }}/discover/use-cases/">Find out how Ceph is used</a>
       <h3 class="h3">From start up to enterprise</h3>
-      <p class="mb-8 lg:mb-12 p">
+      <p class="p">
         From humble beginnings as a PhD thesis, to becoming an established and acclaimed enterprise storage solution, Ceph has undergone
         unimaginable growth, much like the growth in demand for ever-expanding data storage. By going global and gathering contributions
         from the best of the best, Ceph has evolved from a hypothesised idea to a substantial creation fit for enterprise use around the
         world.
       </p>
+      <a class="a inline-block mb-8 lg:mb-12" href="/{{ locale }}/foundation/history/">Read the full Ceph story</a>
       <h3 class="h3">Constant growth</h3>
       <p class="p">
         Through combining the innovative collaboration of Ceph’s community with the uptake of Ceph as a popular storage solution, Ceph is

--- a/src/en/discover/vision/index.html
+++ b/src/en/discover/vision/index.html
@@ -48,16 +48,16 @@ overlaySubMenu: true
   </div>
   <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
     <div>
-      <h3 class="h3">Crimson and Seastore</h3>
+      <h3 class="h3">Crimson and SeaStore</h3>
       <p class="p">
         Crimson is Ceph's next-generation OSD, rebuilt from the ground up on the Seastar framework: a shared-nothing, one-thread-per-core
         design that keeps work on the CPU core that owns it and avoids the locks, context switches, and kernel overhead that limit today's
         storage daemons.
       </p>
       <p class="p">
-        Crimson shipped its first technology preview in the Squid release, and Tentacle added Seastore, Crimson's purpose-built object store
-        designed for flash rather than spinning disks. The goal is a drop-in replacement for the classic OSD: speaking the same librados
-        protocol, joining the same clusters, with Seastore as its native backend.
+        Crimson shipped its first technology preview in the Squid release, and Tentacle added SeaStore, Crimson's purpose-built object store
+        designed for flash rather than spinning disks. The goal is a drop-in replacement for the classic OSD: speaking the same RADOS
+        protocol, joining the same clusters, with SeaStore as its native backend.
       </p>
       <a class="a block mb-4" href="/{{ locale }}/developers/crimson/">Explore the Crimson project</a>
       <a class="a" href="/{{ locale }}/news/blog/2025/crimson-seastore-vs-classic/">Read the early Crimson benchmarks</a>
@@ -99,6 +99,7 @@ overlaySubMenu: true
         Beyond Kubernetes, cephadm deploys and manages every Ceph daemon in containers: the same declarative, self-managing operational
         model from bare metal to cloud. Wherever your platform runs, Ceph runs the way your platform expects.
       </p>
+      <a class="a" href="/{{ locale }}/users/cloud-native/">Run Ceph on Kubernetes</a>
     </div>
     <div class="bg-grey-300 p-5 rounded-2">
       <h3 class="h3">Cloud-native resources</h3>

--- a/src/en/discover/why-ceph/index.html
+++ b/src/en/discover/why-ceph/index.html
@@ -1,0 +1,158 @@
+---
+title: Why Ceph
+order: 6
+overlaySubMenu: true
+---
+
+{% set caseStudyLocaleTag = locale + '-case-study' %} {% set recentCaseStudies = collections[caseStudyLocaleTag] | reverse | getItems(6) %}
+
+<h1 class="h1 visually-hidden">{{ title }}</h1>
+
+<section class="bg-navy section section--full">
+  <div class="wrapper">
+    <div class="max-w-224 mx-auto py-16 text-center">
+      <h2 class="color-white h1">One storage platform. No lock-in. No limits.</h2>
+      <p class="color-white mb-0 standout">
+        Your choice of storage solution can be a decade-long commitment. Ceph is the choice that keeps every other choice open: any
+        hardware, any scale, any interface, with no license fees and no vendor holding the keys.
+      </p>
+    </div>
+  </div>
+</section>
+
+<ul class="sub-menu">
+  <li>
+    <a href="#freedom"><img alt="" src="/assets/svgs/icon-innovation-blue-red.svg" />Freedom from lock-in</a>
+  </li>
+  <li>
+    <a href="#unified"><img alt="" src="/assets/svgs/icon-rados-blue-red.svg" />One unified platform</a>
+  </li>
+  <li>
+    <a href="#compare"><img alt="" src="/assets/svgs/icon-benefits-blue-red.svg" />How Ceph compares</a>
+  </li>
+  <li>
+    <a href="#proof"><img alt="" src="/assets/svgs/icon-case-study-blue-red.svg" />Proven at scale</a>
+  </li>
+</ul>
+
+<section class="section">
+  <h2 class="h2 mb-12 lg:mb-16" id="freedom">Freedom from lock-in</h2>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        Ceph runs on commodity hardware from any vendor, and it is free and open source software: no license fees, no locked feature tiers,
+        and no penalty for leaving.
+      </p>
+      <p class="p">
+        That independence compounds over time. You choose drives and servers on price and performance rather than on a compatibility list,
+        refresh hardware on your schedule rather than a contract cycle, and mix generations and vendors freely inside one cluster. When
+        priorities change, your data does not need an exit plan: the platform moves with you, from a homelab to a data center to a hybrid
+        deployment.
+      </p>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h3 class="h3">Dig deeper</h3>
+      <ul class="list-none p-0">
+        <li class="mb-6">
+          <strong class="block p">The benefits of Ceph</strong>
+          <p class="mb-0 p">
+            Performance, scalability, reliability, and the economics of open source, on the
+            <a class="a" href="/{{ locale }}/discover/benefits/">benefits page</a>.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Hardware guidance</strong>
+          <p class="mb-0 p">
+            What to look for in CPUs, memory, drives, and networks, in the
+            <a class="a" href="https://docs.ceph.com/en/latest/start/hardware-recommendations/">hardware recommendations</a>.
+          </p>
+        </li>
+        <li class="mb-0">
+          <strong class="block p">A vendor-neutral home</strong>
+          <p class="mb-0 p">
+            Ceph is governed by its community and supported by the
+            <a class="a" href="/{{ locale }}/foundation/members/">Ceph Foundation members</a>, not owned by any single company.
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <h2 class="h2 mb-12 lg:mb-16" id="unified">One unified platform</h2>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        Most storage estates grow into three separate systems: one for object storage, one for block, one for file, each with its own
+        hardware, licensing, and operational playbook.
+      </p>
+      <p class="p">
+        Ceph replaces that sprawl with a single cluster built on RADOS. The same pool of storage serves S3-compatible object storage,
+        virtual machine and container block devices, and a POSIX-compliant file system, with one set of hardware, one operational model, and
+        one community behind it. Many open source storage projects solve one protocol or one niche well; Ceph is a general-purpose
+        foundation designed to carry all three, at any scale.
+      </p>
+      <a class="a" href="/{{ locale }}/discover/technology/">See how the technology works</a>
+    </div>
+  </div>
+</section>
+
+<section class="bg-grey-300 section section--full">
+  <div class="wrapper">
+    <h2 class="h2 text-center" id="compare">How Ceph compares</h2>
+    <ul class="grid lg:grid--cols-3 list-none mb-0 p-0">
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-scalable-blue-red.svg" />
+        <h3 class="h3">Vs. proprietary storage</h3>
+        <p class="p">
+          Proprietary arrays couple your data to one vendor's hardware, one license, and one support contract. Ceph delivers the same
+          enterprise capabilities, replication, erasure coding, snapshots, and self-healing, as open source software on hardware you choose.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/benefits/">Explore the benefits</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-reliable-blue-red.svg" />
+        <h3 class="h3">Vs. cloud-only storage</h3>
+        <p class="p">
+          Public cloud storage is convenient until the bill, the egress fees, or the compliance rules arrive. Ceph runs wherever you need
+          it: on premises, in a private cloud, at the edge, or alongside public cloud, with your data on your hardware.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/use-cases/">See the use cases</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-rados-blue-red.svg" />
+        <h3 class="h3">Vs. single-purpose systems</h3>
+        <p class="p">
+          Point solutions do one thing, then multiply: more systems, more silos, more to operate. One Ceph cluster provides object, block,
+          and file storage together, so capacity and expertise pool instead of fragmenting.
+        </p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/technology/">One platform, three interfaces</a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="section">
+  <div class="max-w-192 mx-auto text-center">
+    <h2 class="h2">Open source, open governance</h2>
+    <p class="p">
+      Ceph is developed in public and governed by its community, with the Ceph Foundation providing a neutral home under the Linux
+      Foundation. The direction of the project is set by the people who build and run it, not by a product roadmap you cannot see. Read
+      about <a class="a" href="/{{ locale }}/discover/vision/#open-source">how Ceph is democratizing storage</a> or meet the
+      <a class="a" href="/{{ locale }}/foundation/">Ceph Foundation</a>.
+    </p>
+  </div>
+</section>
+
+<hr class="hr" />
+
+<section class="section">
+  <h2 class="h2 mb-12 lg:mb-16" id="proof">Proven at scale</h2>
+  <ul class="grid grid--cols-2 md:grid--cols-3 lg:grid--cols-6 list-none m-0 mb-8 lg:mb-12 p-0">
+    {% for item in recentCaseStudies %}
+    <li>{% include "components/case-study-card.njk" %}</li>
+    {% endfor %}
+  </ul>
+  <a class="a" href="/{{ locale }}/discover/case-studies/">Browse all case studies</a>
+</section>

--- a/src/en/foundation/history/index.html
+++ b/src/en/foundation/history/index.html
@@ -1,0 +1,165 @@
+---
+title: History
+order: 2
+overlaySubMenu: true
+---
+
+<h1 class="h1 visually-hidden">{{ title }}</h1>
+
+<section class="bg-navy section section--full">
+  <div class="wrapper">
+    <div class="max-w-224 mx-auto py-16 text-center">
+      <h2 class="color-white h1">Two decades of open storage.</h2>
+      <p class="color-white mb-0 standout">
+        From a graduate research project to the storage foundation behind clouds, research clusters, and enterprises worldwide: the story of
+        Ceph is the story of open source done right.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="max-w-192 mx-auto text-center">
+    <h2 class="h2">From thesis to foundation</h2>
+    <p class="mb-12 lg:mb-16 p">
+      Ceph began as research at the Storage Systems Research Center at the University of California, Santa Cruz, funded by a grant from
+      Lawrence Livermore, Sandia, and Los Alamos National Laboratories. Every chapter since has followed the same principle: build the
+      future of storage in the open.
+    </p>
+  </div>
+
+  <ol class="timeline">
+    <li class="timeline__item">
+      <p class="p timeline__year">2004</p>
+      <div>
+        <h3 class="h3">Research begins</h3>
+        <p class="mb-0 p">
+          Sage Weil joins the Storage Systems Research Center at UC Santa Cruz, and the first lines of Ceph are written as part of a
+          national-laboratory-funded effort to build petabyte-scale storage. The first Ceph paper, on dynamic metadata management, appears
+          at the SC supercomputing conference that November. See the
+          <a class="a" href="/{{ locale }}/news/publications/">research publications</a>.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2006</p>
+      <div>
+        <h3 class="h3">Ceph goes public</h3>
+        <p class="mb-0 p">
+          The <a class="a" href="/assets/pdfs/weil-ceph-osdi06.pdf">Ceph paper</a> appears at OSDI and the
+          <a class="a" href="/assets/pdfs/weil-crush-sc06.pdf">CRUSH data placement paper</a> appears at SC, and the code is publicly
+          available as open source under the LGPL.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2007</p>
+      <div>
+        <h3 class="h3">The thesis, and a new home</h3>
+        <p class="mb-0 p">
+          Sage Weil completes his <a class="a" href="/assets/pdfs/weil-thesis.pdf">PhD thesis</a> on Ceph at UC Santa Cruz. Development
+          continues at DreamHost, the Los Angeles web hosting company he co-founded, which supported the Ceph team for years.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2010</p>
+      <div>
+        <h3 class="h3">Into the Linux kernel</h3>
+        <p class="mb-0 p">
+          The Ceph client is
+          <a class="a" href="/{{ locale }}/news/blog/2010/client-merged-for-2-6-34/">merged into the mainline Linux kernel</a>, letting
+          Linux mount Ceph file systems without any additional patches.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2012</p>
+      <div>
+        <h3 class="h3">Inktank and the first stable series</h3>
+        <p class="mb-0 p">
+          Sage Weil and the Ceph team
+          <a class="a" href="/{{ locale }}/news/blog/2012/announcing-the-ceph-com-refresh/">launch Inktank</a> to provide commercial
+          services and support for Ceph, and <a class="a" href="/{{ locale }}/news/blog/2012/v0-48-argonaut-released/">Argonaut</a> ships as
+          the basis of the first long-term stable Ceph release series.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2014</p>
+      <div>
+        <h3 class="h3">Red Hat, and ten years of Ceph</h3>
+        <p class="mb-0 p">
+          <a class="a" href="/{{ locale }}/news/blog/2014/red-hat-to-acquire-inktank/">Red Hat acquires Inktank</a>, ten years after the
+          first line of Ceph code was written, and the community
+          <a class="a" href="/{{ locale }}/news/blog/2014/celebrate-10-years-ceph-oscon/">celebrates ten years of Ceph</a> at OSCON in
+          Portland.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2018</p>
+      <div>
+        <h3 class="h3">Cephalocon and the Ceph Foundation</h3>
+        <p class="mb-0 p">
+          The <a class="a" href="/{{ locale }}/news/blog/2018/cephalocon-apac-2018-report/">first Cephalocon</a> draws more than 1,000
+          attendees in Beijing. In November, the
+          <a class="a" href="/{{ locale }}/news/blog/2018/announce-the-ceph-foundation/">Ceph Foundation launches</a> at Ceph Day Berlin as
+          a directed fund under the Linux Foundation, with 31 founding member organizations.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">2026</p>
+      <div>
+        <h3 class="h3">A charter for the next era</h3>
+        <p class="mb-0 p">
+          The Ceph Foundation Charter is established and the Ceph Technical Charter is
+          <a class="a" href="/{{ locale }}/news/blog/2026/Q1-community-newsletter/">approved by the Ceph Steering Committee</a>, completing
+          a governance model that keeps technical decision-making with the community while the Foundation focuses on funding, outreach, and
+          ecosystem growth.
+        </p>
+      </div>
+    </li>
+    <li class="timeline__item">
+      <p class="p timeline__year">Today</p>
+      <div>
+        <h3 class="h3">The future of storage</h3>
+        <p class="mb-0 p">
+          Ceph ships a new named stable release every year, each supported for approximately two years, governed by the
+          <a class="a" href="https://docs.ceph.com/en/latest/governance/"
+            >Ceph Steering Committee and an annually elected Executive Council</a
+          >. The next chapters, from the Crimson OSD to the flash-native era, are being written in public. Read about them on the
+          <a class="a" href="/{{ locale }}/discover/vision/">Vision page</a>.
+        </p>
+      </div>
+    </li>
+  </ol>
+</section>
+
+<section class="pt-0 section">
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <h2 class="h2">The community today</h2>
+      <p class="p">
+        What began as one graduate student's research is now built and steered by contributors and member organizations around the world.
+        Join the <a class="a" href="/{{ locale }}/community/">Ceph community</a>, meet the
+        <a class="a" href="/{{ locale }}/foundation/members/">Foundation members</a>, or see
+        <a class="a" href="/{{ locale }}/discover/vision/">where Ceph is heading next</a>.
+      </p>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h2 class="h3">Read the primary sources</h2>
+      <ul class="list-none p-0">
+        <li class="mb-4 p"><a class="a" href="/{{ locale }}/news/publications/">The original research papers</a>, 2004 to 2007</li>
+        <li class="mb-4 p"><a class="a" href="/assets/pdfs/weil-thesis.pdf">Sage Weil's PhD thesis</a>, December 2007</li>
+        <li class="mb-4 p">
+          <a class="a" href="/{{ locale }}/news/blog/2014/red-hat-to-acquire-inktank/">The Red Hat acquisition announcement</a>, 2014
+        </li>
+        <li class="mb-0 p">
+          <a class="a" href="/{{ locale }}/news/blog/2018/announce-the-ceph-foundation/">The Ceph Foundation announcement</a>, 2018
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>

--- a/src/en/users/cloud-native/index.html
+++ b/src/en/users/cloud-native/index.html
@@ -1,0 +1,139 @@
+---
+title: Cloud native
+order: 4
+overlaySubMenu: true
+---
+
+<h1 class="h1 visually-hidden">{{ title }}</h1>
+
+<section class="bg-navy section section--full">
+  <div class="wrapper">
+    <div class="max-w-224 mx-auto py-16 text-center">
+      <h2 class="color-white h1">Ceph is Kubernetes-native storage.</h2>
+      <p class="color-white mb-0 standout">
+        Deploy and manage entire Ceph clusters through Kubernetes with the Rook operator, provision block and file volumes on demand with
+        the Ceph CSI driver, and run every daemon in containers wherever your platform lives.
+      </p>
+    </div>
+  </div>
+</section>
+
+<ul class="sub-menu">
+  <li>
+    <a href="#rook"><img alt="" src="/assets/svgs/icon-container-blue-red.svg" />Rook operator</a>
+  </li>
+  <li>
+    <a href="#csi"><img alt="" src="/assets/svgs/icon-block-blue-red.svg" />Ceph CSI</a>
+  </li>
+  <li>
+    <a href="#containers"><img alt="" src="/assets/svgs/icon-ceph-deploy-blue-red.svg" />Containerized Ceph</a>
+  </li>
+</ul>
+
+<section class="section">
+  <h2 class="h2 mb-12 lg:mb-16" id="rook">Run Ceph with the Rook operator</h2>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        Rook is the Ceph documentation's preferred way to run Ceph on Kubernetes: a specialized operator that deploys, configures, upgrades,
+        and manages whole clusters through Kubernetes APIs.
+      </p>
+      <p class="p">
+        A graduated Cloud Native Computing Foundation project, Rook turns Ceph into a set of Kubernetes resources: declare the cluster you
+        want, and the operator makes it so, handling bootstrap, monitor placement, OSD provisioning, and day-two operations. It also
+        connects Kubernetes workloads to existing external Ceph clusters, so the same storage can serve platforms inside and outside
+        Kubernetes.
+      </p>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h3 class="h3">Get started with Rook</h3>
+      <ul class="list-none p-0">
+        <li class="mb-6">
+          <strong class="block p">Rook project</strong>
+          <p class="mb-0 p">
+            Overview, community, and releases at <a class="a" href="https://rook.io/">rook.io</a>, with development in the open on
+            <a class="a" href="https://github.com/rook/rook">GitHub</a>.
+          </p>
+        </li>
+        <li class="mb-6">
+          <strong class="block p">Quickstart</strong>
+          <p class="mb-0 p">
+            A test cluster is a few manifests away: follow the
+            <a class="a" href="https://rook.io/docs/rook/latest-release/Getting-Started/quickstart/">Rook quickstart guide</a>.
+          </p>
+        </li>
+        <li class="mb-0">
+          <strong class="block p">Recommended methods</strong>
+          <p class="mb-0 p">
+            The <a class="a" href="https://docs.ceph.com/en/latest/install/">Ceph installation guide</a> recommends Rook for Kubernetes and
+            cephadm everywhere else.
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <h2 class="h2 mb-12 lg:mb-16" id="csi">Volumes on demand with Ceph CSI</h2>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        The Ceph CSI driver provisions storage for Kubernetes workloads dynamically: RBD-backed block volumes and CephFS-backed shared file
+        volumes, created the moment a claim asks for them.
+      </p>
+      <p class="p">
+        Snapshots, cloning, and volume expansion are built in, so the storage features platform teams expect from a cloud arrive with your
+        own cluster. Because RBD images are striped as objects across the cluster, container volumes inherit Ceph's replication,
+        self-healing, and scale.
+      </p>
+      <a class="a block mb-4" href="https://docs.ceph.com/en/latest/rbd/rbd-kubernetes/">Block devices and Kubernetes</a>
+      <a class="a" href="https://github.com/ceph/ceph-csi">Ceph CSI on GitHub</a>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <h2 class="h2 mb-12 lg:mb-16" id="containers">Containerized everywhere</h2>
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        Outside Kubernetes, cephadm deploys and manages every Ceph daemon in containers, using Podman or Docker under systemd.
+      </p>
+      <p class="p">
+        It is one of the two installation methods the documentation recommends, and it brings the same declarative, self-managing model to
+        bare metal and virtual machines: a containerized control plane, integrated upgrades, and orchestration through the CLI and
+        dashboard.
+      </p>
+      <a class="a" href="https://docs.ceph.com/en/latest/cephadm/">Read the cephadm guide</a>
+    </div>
+  </div>
+</section>
+
+<section class="bg-grey-300 section section--full">
+  <div class="wrapper">
+    <h2 class="h2 text-center">Discover more</h2>
+    <ul class="grid lg:grid--cols-3 list-none mb-0 p-0">
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-case-study-blue-red.svg" />
+        <h3 class="h3">Cloud-native storage in practice</h3>
+        <p class="p">An introduction to persistent container storage with Ceph, from the case studies collection.</p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/case-studies/ceph-persistent-container-storage/"
+          >Read the case study</a
+        >
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-innovation-blue-red.svg" />
+        <h3 class="h3">Our cloud-native vision</h3>
+        <p class="p">Why Ceph is built to live where modern platforms live, on the Vision page's cloud-native section.</p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/discover/vision/#cloud-native">Read the vision</a>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid p-5 relative rounded-2">
+        <img alt="" class="mb-4 w-12" src="/assets/svgs/icon-documentation-blue-red.svg" />
+        <h3 class="h3">Getting started</h3>
+        <p class="p">Packages, containers, and your first cluster: everything you need to begin running Ceph today.</p>
+        <a class="a link-cover link-cover--shadow" href="/{{ locale }}/users/getting-started/">Get started with Ceph</a>
+      </li>
+    </ul>
+  </div>
+</section>

--- a/src/en/users/faq/index.html
+++ b/src/en/users/faq/index.html
@@ -1,0 +1,178 @@
+---
+title: FAQ
+order: 5
+overlaySubMenu: true
+---
+
+<h1 class="h1 visually-hidden">{{ title }}</h1>
+
+<section class="bg-navy section section--full">
+  <div class="wrapper">
+    <div class="max-w-224 mx-auto py-16 text-center">
+      <h2 class="color-white h1">Frequently asked questions</h2>
+      <p class="color-white mb-0 standout">Quick answers to common questions, with links into the documentation for the full detail.</p>
+    </div>
+  </div>
+</section>
+
+<ul class="sub-menu">
+  <li>
+    <a href="#getting-started"><img alt="" src="/assets/svgs/icon-documentation-blue-red.svg" />Getting started</a>
+  </li>
+  <li>
+    <a href="#planning"><img alt="" src="/assets/svgs/icon-crush-blue-red.svg" />Planning and hardware</a>
+  </li>
+  <li>
+    <a href="#project"><img alt="" src="/assets/svgs/icon-contribute-blue-red.svg" />The project and community</a>
+  </li>
+</ul>
+
+<section class="section">
+  <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
+    <div>
+      <p class="standout">
+        New to Ceph, or planning your first cluster? These are the questions we hear most often. Each answer links into the documentation,
+        where the full detail lives.
+      </p>
+      <p class="p">
+        Questions about the Ceph Foundation itself, such as membership and governance, are answered in the
+        <a class="a" href="/{{ locale }}/foundation/about/">Foundation FAQ</a>.
+      </p>
+    </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h2 class="h3">Where to get help</h2>
+      <ul class="list-none p-0">
+        <li class="mb-4 p"><a class="a" href="https://docs.ceph.com/en/latest/">docs.ceph.com</a>: the complete documentation</li>
+        <li class="mb-4 p">
+          <a class="a" href="https://lists.ceph.io/postorius/lists/ceph-users.ceph.io/">ceph-users mailing list</a>: operational questions
+          and community support
+        </li>
+        <li class="mb-4 p"><a class="a" href="/{{ locale }}/community/connect/">Community channels</a>: Slack, lists, and social</li>
+        <li class="mb-0 p"><a class="a" href="https://tracker.ceph.com/">tracker.ceph.com</a>: report bugs and request features</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <div class="max-w-256">
+    <h2 class="h2 mb-8 lg:mb-12" id="getting-started">Getting started</h2>
+
+    <details class="details" open>
+      <summary>What is Ceph?</summary>
+      <p class="p">
+        Ceph is an open source distributed storage system that delivers object, block, and file storage in one unified platform. It runs on
+        commodity hardware, replicates data across the cluster, and heals itself when disks or nodes fail. Start with the
+        <a class="a" href="https://docs.ceph.com/en/latest/start/">introduction in the documentation</a>.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>How do I try Ceph quickly?</summary>
+      <p class="p">
+        The fastest path is cephadm: bootstrap a cluster on a single host, then expand it host by host. You need Python 3, systemd, a
+        container runtime (Podman or Docker), time synchronization, and LVM2. Follow the
+        <a class="a" href="https://docs.ceph.com/en/latest/cephadm/install/">cephadm installation guide</a> or our
+        <a class="a" href="/{{ locale }}/users/getting-started/">getting started page</a>.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>Is Ceph production ready?</summary>
+      <p class="p">
+        Yes. Ceph powers production storage for organizations worldwide, from research institutions to cloud providers. The project ships a
+        new stable release every year, supports each series for approximately 24 months, and publishes point releases every 4 to 6 weeks.
+        See the <a class="a" href="https://docs.ceph.com/en/latest/releases/general/">release cadence documentation</a> and our
+        <a class="a" href="/{{ locale }}/discover/case-studies/">case studies</a>.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>Does Ceph work with Kubernetes?</summary>
+      <p class="p">
+        Yes. The documentation recommends Rook, a graduated CNCF project, as the way to run Ceph in Kubernetes or to connect an existing
+        cluster to Kubernetes, and the Ceph CSI driver provisions block and file volumes for workloads. See our
+        <a class="a" href="/{{ locale }}/users/cloud-native/">cloud native page</a>.
+      </p>
+    </details>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <div class="max-w-256">
+    <h2 class="h2 mb-8 lg:mb-12" id="planning">Planning and hardware</h2>
+
+    <details class="details" open>
+      <summary>What hardware do I need?</summary>
+      <p class="p">
+        Ceph is designed for commodity hardware; there is no compatibility list to buy against. The documentation's guidance covers CPU,
+        memory (plan for the OSD memory target, 4 GiB by default, per OSD), separate drives for the operating system and OSD data, and at
+        least 10 Gb/s networking between hosts. Read the
+        <a class="a" href="https://docs.ceph.com/en/latest/start/hardware-recommendations/">hardware recommendations</a>.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>What is the minimum cluster size?</summary>
+      <p class="p">
+        For testing, a single monitor, manager, and OSD will run. For production, the documentation recommends at least three monitors for
+        quorum and high availability, at least two managers, and at least three OSDs (or as many as there are copies of each object). See
+        the <a class="a" href="https://docs.ceph.com/en/latest/start/">getting started documentation</a>.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>Should I use replication or erasure coding?</summary>
+      <p class="p">
+        Pools are replicated by default: simple, fast, and resilient. Erasure coding stores the same data with less raw capacity (profiles
+        like 4+2 or 6+3 roughly double the usable space compared to three-way replication) at a performance cost that is most visible on
+        hard drives and during recovery. The
+        <a class="a" href="https://docs.ceph.com/en/latest/rados/operations/erasure-code/">erasure coding documentation</a> covers the
+        tradeoffs.
+      </p>
+    </details>
+  </div>
+</section>
+
+<section class="pt-0 section">
+  <div class="max-w-256">
+    <h2 class="h2 mb-8 lg:mb-12" id="project">The project and community</h2>
+
+    <details class="details" open>
+      <summary>How does Ceph compare with proprietary or cloud storage?</summary>
+      <p class="p">
+        Ceph delivers enterprise storage capabilities as free and open source software on hardware you choose, with no license fees and no
+        lock-in, and it runs on premises, in private clouds, or alongside public cloud. See
+        <a class="a" href="/{{ locale }}/discover/why-ceph/">why Ceph</a> for the full comparison.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>Who uses Ceph?</summary>
+      <p class="p">
+        Businesses, cloud providers, universities, and research institutions around the world. Browse the
+        <a class="a" href="/{{ locale }}/discover/use-cases/">use cases</a> and
+        <a class="a" href="/{{ locale }}/discover/case-studies/">case studies</a>, or explore the
+        <a class="a" href="https://telemetry-public.ceph.com/">public telemetry dashboard</a> for opt-in statistics from real clusters.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>How do I contribute?</summary>
+      <p class="p">
+        Code, documentation, testing, and bug reports are all welcome. The
+        <a class="a" href="/{{ locale }}/developers/contribute/">contribute page</a> walks through the workflow, and the
+        <a class="a" href="https://docs.ceph.com/en/latest/dev/developer_guide/">developer guide</a> covers the details.
+      </p>
+    </details>
+
+    <details class="details">
+      <summary>What license is Ceph released under?</summary>
+      <p class="p">
+        Most of Ceph is dual licensed under the LGPL version 2.1 or 3.0, as stated in the project's COPYING file. Some bundled components
+        carry other free software licenses, such as BSD 3-clause, Boost, and Apache 2.0, and the documentation is licensed under CC BY-SA
+        3.0.
+      </p>
+    </details>
+  </div>
+</section>

--- a/src/en/users/getting-started/index.html
+++ b/src/en/users/getting-started/index.html
@@ -70,6 +70,14 @@ overlaySubMenu: true
       </p>
       <a class="button" href="https://docs.ceph.com/en/latest/install/">Ceph Installation Guide</a>
     </div>
+    <div class="bg-grey-300 p-5 rounded-2">
+      <h3 class="h3">Deploying on Kubernetes?</h3>
+      <p class="p">
+        The Rook operator deploys and manages Ceph clusters through Kubernetes APIs, and the Ceph CSI driver provisions volumes for your
+        workloads.
+      </p>
+      <a class="a" href="/{{ locale }}/users/cloud-native/">Ceph on Kubernetes</a>
+    </div>
   </div>
 </section>
 

--- a/src/en/users/index.html
+++ b/src/en/users/index.html
@@ -23,9 +23,11 @@ overlaySubMenu: true
     <div class="grid lg:grid--cols-2 grid--gap-14 lg:grid--gap-28">
       <div>
         <p class="standout">
-          The Ceph Foundation upholds the belief that every storage challenge can find its resolution through the power and versatility of open-source software.
+          The Ceph Foundation upholds the belief that every storage challenge can find its resolution through the power and versatility of
+          open-source software.
         </p>
         <a class="button" href="https://docs.ceph.com/">Getting started with Ceph</a>
+        <a class="a block mt-4" href="/{{ locale }}/users/faq/">Frequently asked questions</a>
       </div>
       <div class="bg-grey-300 p-5 rounded-2">
         <h3 class="h3">Telemetry</h3>
@@ -47,7 +49,7 @@ overlaySubMenu: true
 <section class="bg-grey-300 section section--full">
   <div class="wrapper">
     <h2 class="h2 mb-12 lg:mb-16 text-center">Dive into Ceph</h2>
-    <ul class="grid lg:grid--cols-3 list-none m-0 p-0">
+    <ul class="grid md:grid--cols-2 list-none m-0 p-0">
       <li class="bg-white border-grey-500 border-px border-solid relative rounded-2">
         <div class="grid grid--gap-0 md-to-lg:grid--cols-2 overflow-hidden rounded-2">
           <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--cover md-to-lg:h-full tint tint--black-2">
@@ -95,6 +97,22 @@ overlaySubMenu: true
             </p>
             <p class="p">How ever you get involved, with whatever skills you present, Ceph would be glad to have you.</p>
             <a class="a link-cover link-cover--shadow" href="/{{ locale }}/developers/contribute/">Contribute</a>
+          </div>
+        </div>
+      </li>
+      <li class="bg-white border-grey-500 border-px border-solid relative rounded-2">
+        <div class="grid grid--gap-0 md-to-lg:grid--cols-2 overflow-hidden rounded-2">
+          <div class="aspect-ratio aspect-ratio--16x9 aspect-ratio--cover md-to-lg:h-full tint tint--black-2">
+            <img alt="" class="absolute md-to-lg:h-full left-0 top-0" loading="lazy" src="/assets/bitmaps/photo-jelly-fish-01.jpg" />
+            <img alt="" class="absolute bottom-0 left-0 m-4 w-12 z-1" src="/assets/svgs/icon-container-white-red.svg" />
+          </div>
+          <div class="p-5">
+            <h3 class="h3">Cloud native</h3>
+            <p class="p">
+              Run Ceph where your platforms live: deploy and manage clusters on Kubernetes with the Rook operator, and provision block and
+              file volumes for workloads with the Ceph CSI driver.
+            </p>
+            <a class="a link-cover link-cover--shadow" href="/{{ locale }}/users/cloud-native/">Ceph on Kubernetes</a>
           </div>
         </div>
       </li>


### PR DESCRIPTION
## Summary

Four brand-new pages completing the New Content section of the revamp board, built in the site's established design language (navy heroes, sub-menu anchors, two-column sections, white icon cards on grey bands).

**Why Ceph** (`/en/discover/why-ceph/`, Discover order 6)
- Competitive positioning kept at the category level, no vendor or project names: freedom from lock-in, one unified platform instead of three separate systems, and comparison cards against proprietary arrays, cloud-only storage, and single-purpose systems
- Ends with a six-card case-study proof strip reusing the existing `case-study-card.njk` component and collection

**Cloud native** (`/en/users/cloud-native/`, Users order 4)
- The operational home for Ceph on Kubernetes: the Rook operator (CNCF graduated, the docs' preferred method, verified active), the Ceph CSI driver (block and file provisioning with snapshots, cloning, and expansion), and containerized deployment with cephadm
- Claims verified against docs.ceph.com, cncf.io, rook.io, and the ceph-csi README as of this week; alpha features (NFS, NVMe-oF) and experimental COSI deliberately omitted

**FAQ** (`/en/users/faq/`, Users order 5)
- Eleven questions across three groups (getting started, planning and hardware, the project and community) using the site's existing `details` accordion component
- Every answer is sourced from and linked into the documentation, including the docs' own minimum-cluster-size numbers and the actual license statement from the ceph/ceph COPYING file (dual LGPL 2.1/3.0)
- One dead docs URL caught during verification (the old start/intro page 404s) and avoided
- Links to the existing Foundation FAQ instead of duplicating it

**History** (`/en/foundation/history/`, Foundation order 2, next to About)
- The story from 2004 UC Santa Cruz research through DreamHost, Inktank, Red Hat, the Foundation, and the 2026 charters, on a new timeline component
- Every milestone verified against primary sources, with the repo's own posts and PDFs winning conflicts; notably, open-sourcing is anchored to 2006 (the OSDI '06 paper itself states the LGPL release), not the commonly repeated 2007
- Timeline entries link to the original papers, the thesis, and the announcement blog posts

**Supporting changes**
- New `component.timeline.css` (token-based, single column on mobile, year rail at desktop), registered in `main.css`
- New `icon-container-white-red.svg` derived from the existing blue/white icon pair convention
- Cross-links: users hub gains a Cloud native photo card (grid now 2x2) and an FAQ link; discover hub links Why Ceph and History from its existing bands; the Vision page's cloud-native section links the new deep-dive; Getting started gains a "Deploying on Kubernetes?" panel

## Test plan

- [x] Full build (eleventy, postcss, rollup, assets) passes; four pages render in dist
- [x] Timeline and details CSS survive PurgeCSS (checked in built main.css)
- [x] Every internal href on the four new pages resolves to a file in dist (scripted sweep, zero broken)
- [x] All sub-menu anchors match section ids
- [x] External links verified HTTP 200 by research agents this week (docs.ceph.com, rook.io, cncf.io, GitHub, telemetry dashboard)
- [x] New nav entries appear under Discover, Users, and Foundation in the rendered header
- [x] No em dashes; US spelling
- [ ] Visual check of the four pages and the users hub at desktop and mobile widths
